### PR TITLE
Start of autobuild TSV and re-enable consistency checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_downloads/
 
 # PyBuilder
 target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ matrix:
       install:
         - pip install pyyaml pandas xlrd deepdiff jinja2 jsondiff
       script:
-        - scripts/check-consistency-miairr.py
+        - tests/check-consistency-miairr.py
+        - tests/check-consistency-formats.py
     - language: python
       python:
         - 3.6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -235,23 +235,20 @@ html_context = {'airr_schema': airr_schema}
 
 # Write download spec files
 import csv
-fields = ['Name', 'Type', 'Priority', 'Description']
-specs = ['Rearrangement', 'Alignment']
 dl_path = '_downloads'
 if not os.path.exists(dl_path):  os.mkdir(dl_path)
 
-# Define rows
-def build_spec(spec, schema=airr_schema):
-    rows = [{'Name': k,
-             'Type': v['type'],
-             'Priority': 'required' if k in airr_schema[spec]['required'] else '',
-             'Description': v['description']} \
-            for k, v in schema[spec]['properties'].items()]
-    return rows
-
-# Build TSVs
-for s in specs:
-    with open(os.path.join(dl_path, '%s.tsv' % s), 'w') as f:
-        writer = csv.DictWriter(f, dialect='excel-tab', fieldnames=fields)
-        writer.writeheader()
-        writer.writerows(build_spec(s))
+# Build table for each spec
+tables = ['Rearrangement', 'Alignment']
+fields = ['Name', 'Type', 'Priority', 'Description']
+for spec in tables:
+    # Get specs
+    required = airr_schema[spec]['required']
+    properties = airr_schema[spec]['properties']
+    # Write TSV
+    with open(os.path.join(dl_path, '%s.tsv' % spec), 'w') as f:
+        writer = csv.writer(f, dialect='excel-tab')
+        rows = ([k, v['type'], 'required' if k in required else '', v['description']] \
+                for k, v in properties.items())
+        writer.writerow(fields)
+        writer.writerows(rows)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,3 +232,26 @@ texinfo_documents = [
 with open(os.path.abspath('../specs/definitions.yaml')) as ip:
     airr_schema = yaml.load(ip, Loader=yamlordereddictloader.Loader)
 html_context = {'airr_schema': airr_schema}
+
+# Write download spec files
+import csv
+fields = ['Name', 'Type', 'Priority', 'Description']
+specs = ['Rearrangement', 'Alignment']
+dl_path = '_downloads'
+if not os.path.exists(dl_path):  os.mkdir(dl_path)
+
+# Define rows
+def build_spec(spec, schema=airr_schema):
+    rows = [{'Name': k,
+             'Type': v['type'],
+             'Priority': 'required' if k in airr_schema[spec]['required'] else '',
+             'Description': v['description']} \
+            for k, v in schema[spec]['properties'].items()]
+    return rows
+
+# Build TSVs
+for s in specs:
+    with open(os.path.join(dl_path, '%s.tsv' % s), 'w') as f:
+        writer = csv.DictWriter(f, dialect='excel-tab', fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(build_spec(s))

--- a/docs/formats/alignments.rst
+++ b/docs/formats/alignments.rst
@@ -10,6 +10,8 @@ germline reference segment.
 
 **Fields**
 
+:download:`Download as TSV <../_downloads/Alignment.tsv>`.
+
 .. list-table::
     :widths: auto
     :header-rows: 1

--- a/docs/formats/rearrangements.rst
+++ b/docs/formats/rearrangements.rst
@@ -17,6 +17,8 @@ exclude them.
 
 **Fields**
 
+:download:`Download as TSV <../_downloads/Rearrangement.tsv>`.
+
 .. list-table::
     :widths: auto
     :header-rows: 1

--- a/specs/miairr.yaml
+++ b/specs/miairr.yaml
@@ -1,0 +1,492 @@
+study_id:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Study
+   format: free text
+   example: PRJNA001
+study_title:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Study title
+   format: free text
+   example: Effects of sun light exposure of the Treg repertoire
+study_description:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Study type
+   format: controlled vocabulary
+   example: Placebo controlled phase 3 clinical trial
+inclusion_exclusion_criteria:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Study inclusion/exclusion criteria
+   format: free text
+   example: "Include: Clinical P. falciparum infection; Exclude: Seropositive for HIV"
+grants:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Grant funding agency
+   format: free text
+   example: NIH, award number R01GM987654
+collected_by:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Contact information (data collection)
+   format: free text
+   example: p.stibbons@unseenu.edu
+lab_name:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Lab name
+   format: free text
+   example: Department of Planar Immunology
+lab_address:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Lab address
+   format: free text
+   example: School of Medicine, Unseen University, Ankh-Morpork, Disk World
+submitted_by:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Contact information (data deposition)
+   format: free text
+   example: Dr. P. Stibbons
+pub_ids:
+   miairr_set: 1
+   miairr_subset: study
+   miairr_name: Relevant publications
+   format: PubMed ID
+   example: PMID85642
+subject_id:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Subject ID
+   format: free text
+   example: SUB856413
+synthetic:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Synthetic library
+   format: TRUE/FALSE
+   example: FALSE
+organism:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Organism
+   format: controlled vocabulary
+   example: Homo sapiens
+sex:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Sex
+   format: /(male|female|pooled|hermaphrodite|intersex|not collected|not applicable)/
+   example: female
+age:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Age
+   format: time duration and unit
+   example: 65 a
+age_event:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Age event
+   format: free text
+   example: enrollment
+ancestry_population:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Ancestry population
+   format: free text
+   example: list of continents, mixed or unknown
+ethnicity:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Ethnicity
+   format: free text
+   example: English, Kurds, Manchu, Yakuts (and other fields from Wikipedia)
+race:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Race
+   format: free text
+   example: White, American Indian or Alaska Native, Black, Asian, Native Hawaiian or Other Pacific Islander, Other 
+strain_name:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Strain name
+   format: free text
+   example: C57BL/6J
+linked_subjects:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Relation to other subjects
+   format: free text
+   example: SUB1355648
+link_type:
+   miairr_set: 1
+   miairr_subset: subject
+   miairr_name: Relation type
+   format: free text
+   example: father, daughter, household
+study_group_description:
+   miairr_set: 1
+   miairr_subset: diagnosis and intervention
+   miairr_name: Study group description
+   format: free text
+   example: control
+disease_diagnosis:
+   miairr_set: 1
+   miairr_subset: diagnosis and intervention
+   miairr_name: Diagnosis
+   format: free text
+   example: Multiple myeloma
+disease_length:
+   miairr_set: 1
+   miairr_subset: diagnosis and intervention
+   miairr_name: Length of disease
+   format: time duration and unit
+   example: 23 months
+disease_stage:
+   miairr_set: 1
+   miairr_subset: diagnosis and intervention
+   miairr_name: Disease stage
+   format: free text
+   example: Stage II
+prior_therapies:
+   miairr_set: 1
+   miairr_subset: diagnosis and intervention
+   miairr_name: Prior therapies for primary disease under study
+   format: free text
+   example: melphalan/prednisone
+immunogen:
+   miairr_set: 1
+   miairr_subset: diagnosis and intervention
+   miairr_name: Immunogen/agent
+   format: free text
+   example: bortezomib
+intervention:
+   miairr_set: 1
+   miairr_subset: diagnosis and intervention
+   miairr_name: Intervention definition
+   format: free text
+   example: systemic chemotherapy, 6 cycles, 1.25 mg/m2
+medical_history:
+   miairr_set: 1
+   miairr_subset: diagnosis and intervention
+   miairr_name: Other relevant medical history
+   format: free text
+   example: MGUS, first diagnosed 5 years prior
+sample_id:
+   miairr_set: 2
+   miairr_subset: sample
+   miairr_name: Biological sample ID
+   format: free text
+   example: SUP52415
+sample_type:
+   miairr_set: 2
+   miairr_subset: sample
+   miairr_name: Sample type
+   format: free text
+   example: Biopsy
+tissue:
+   miairr_set: 2
+   miairr_subset: sample
+   miairr_name: Tissue
+   format: free text
+   example: Bone marrow
+anatomic_site:
+   miairr_set: 2
+   miairr_subset: sample
+   miairr_name: Anatomic site
+   format: free text
+   example: Iliac crest
+disease_state_sample:
+   miairr_set: 2
+   miairr_subset: sample
+   miairr_name: Disease state of sample
+   format: free text
+   example: Tumor infiltration
+collection_time_point_relative:
+   miairr_set: 2
+   miairr_subset: sample
+   miairr_name: Sample collection time
+   format: free text
+   example: 14 d
+collection_time_point_reference:
+   miairr_set: 2
+   miairr_subset: sample
+   miairr_name: Collection time event
+   format: free text
+   example: Primary vaccination
+biomaterial_provider:
+   miairr_set: 2
+   miairr_subset: sample
+   miairr_name: Biomaterial provider
+   format: free text
+   example: Tissues-R-Us, Tampa, FL, USA
+tissue_processing:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Tissue processing
+   format: free text
+   example: Collagenase A/Dnase I digested, followed by Percoll gradient
+cell_subset:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Cell subset
+   format: controlled vocabulary
+   example: Class-switched Memory B cells
+cell_phenotype:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Cell subset phenotype
+   format: free text
+   example: CD19+ CD38+ CD27+ IgM- IgD-
+single_cell:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Single-cell sort
+   format: TRUE/FALSE
+   example: FALSE
+cell_number:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Number of cells in experiment
+   format: number
+   example: 1000000
+cells_per_reaction:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Number of cells per sequencing reaction
+   format: number
+   example: 50000
+cell_storage:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Cell storage
+   format: TRUE/FALSE
+   example: TRUE
+cell_quality:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Cell quality
+   format: free text
+   example: 90% viability as determined by 7-AAD
+cell_isolation:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Cell isolation / enrichment procedure
+   format: free text
+   example: Cells were stained with fluorochrome labeled antibodies and then sorted on a FlowMerlin (CE) cytometer
+cell_processing_protocol:
+   miairr_set: 3
+   miairr_subset: process (cell)
+   miairr_name: Processing protocol
+   format: free text
+   example: Stimulated wih anti-CD3/anti-CD28
+template_class:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Target substrate
+   format: /(DNA|RNA)/
+   example: RNA
+template_quality:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Target substrate quality
+   format: free text
+   example: RIN 9.2
+template_amount:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Template amount
+   format: free text
+   example: 1000 ng
+library_generation_method:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Library generation method
+   format: controlled vocabulary
+   example: Oligo-dT primed 5' RACE
+library_generation_protocol:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Library generation protocol
+   format: free text
+   example: cDNA was generated using
+library_generation_kit_version:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Protocol IDs
+   format: free text
+   example: v2.1 (2016-09-15)
+pcr_target_locus:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Target locus for PCR
+   format: free text
+   example: Constant region vs. V region amplification
+forward_pcr_primer_target_location:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Forward PCR primer target location
+   format: free text
+   example: IGHV, +23
+reverse_pcr_primer_target_location:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Reverse PCR primer target location
+   format: free text
+   example: IGHG, +57
+complete_sequences:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Complete sequences
+   format: /(partial|complete|complete+untemplated)/
+   example: partial
+physical_linkage:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Physical linkage of different loci
+   format: controlled vocabulary
+   example: IGH-IGK/IGL-head/head
+total_reads_passing_qc_filter:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Total reads passing QC filter
+   format: number
+   example: 10365118
+sequencing_platform:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Sequencing platform
+   format: free text
+   example: Alumina LoSeq 1000
+read_length:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Read lengths
+   format: array of numbers
+   example: "[300,300]"
+sequencing_facility:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Sequencing facility
+   format: free text
+   example: Seqs-R-Us, Vancouver, BC, Canada
+sequencing_run_id:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Batch number
+   format: free text
+   example: 160101_M01234_0201_000000000-D2T7V
+sequencing_run_date:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Date of sequencing run
+   format: ISO8601-compliant date
+   example: 2016-12-16
+sequencing_kit:
+   miairr_set: 3
+   miairr_subset: process (nucleic acid)
+   miairr_name: Sequencing kit
+   format: free text
+   example: "FullSeq 600, Alumina, #M123456C0, 789G1HK"
+raw_data:
+   miairr_set: 4
+   miairr_subset: data (raw reads)
+   miairr_name: Raw sequence data
+   format: FASTQ
+   example: <n/a>
+software_versions:
+   miairr_set: 5
+   miairr_subset: process (computational)
+   miairr_name: Software tools and version numbers
+   format: free text
+   example: IgBLAST 1.6
+paired_reads_assembly:
+   miairr_set: 5
+   miairr_subset: process (computational)
+   miairr_name: Paired read assembly
+   format: free text
+   example: PandaSeq (minimal overlap 50, threshold 0.8)
+quality_thresholds:
+   miairr_set: 5
+   miairr_subset: process (computational)
+   miairr_name: Quality thresholds
+   format: free text
+   example: Average Phred score >=20
+primer_match_cutoffs:
+   miairr_set: 5
+   miairr_subset: process (computational)
+   miairr_name: Primer match cutoffs
+   format: free text
+   example: Hamming distance <= 2
+collapsing_method:
+   miairr_set: 5
+   miairr_subset: process (computational)
+   miairr_name: Collapsing method
+   format: free text
+   example: MUSCLE 3.8.31
+data_processing_protocols:
+   miairr_set: 5
+   miairr_subset: process (computational)
+   miairr_name: Data processing protocols
+   format: free text
+   example: Data was processed using [...]
+germline_database:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: V(D)J germline reference database
+   format: free text
+   example: ENSEMBL, Homo sapiens build 90, 2017-10-01
+cell_id:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: Cell Index
+   format: free text
+   example: W06_046_091
+v_call:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: V gene
+   format: free text
+   example: IGHV1-34*01
+d_call:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: D gene
+   format: free text
+   example: IGHD2-2*01
+j_call:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: J gene
+   format: free text
+   example: IGHJ4*01
+c_call:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: C region
+   format: free text
+   example: IGHG1
+junction:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: IMGT-JUNCTION nucleotide sequence
+   format: free text
+   example: TGTGCAAGAGCGGGAGTTTACGACGGATATACTATGGACTACTGG
+junction_aa:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: IMGT-JUNCTION amino acid sequence
+   format: free text
+   example: CARAGVYDGYTMDYW
+duplicate_count:
+   miairr_set: 6
+   miairr_subset: data (processed sequence)
+   miairr_name: Read count
+   format: number
+   example: 123

--- a/tests/check-consistency-formats.py
+++ b/tests/check-consistency-formats.py
@@ -11,9 +11,12 @@ from glob import glob
 basename = lambda f: os.path.splitext(os.path.basename(f))[0]
 
 # load all paths keyed by their name
-spec_files = {basename(f): f for f in glob('specs/*.yaml')}
-py_files = {basename(f): f for f in glob('lang/python/airr/specs/*.yaml')}
-r_files = {basename(f): f for f in glob('lang/R/inst/extdata/*.yaml')}
+#spec_files = {basename(f): f for f in glob('specs/*.yaml')}
+#py_files = {basename(f): f for f in glob('lang/python/airr/specs/*.yaml')}
+#r_files = {basename(f): f for f in glob('lang/R/inst/extdata/*.yaml')}
+spec_files = {basename(f): f for f in glob('specs/definitions.yaml')}
+py_files = {basename(f): f for f in glob('lang/python/airr/specs/definitions.yaml')}
+r_files = {basename(f): f for f in glob('lang/R/inst/extdata/definitions.yaml')}
 
 # Check python package specs
 if set(spec_files.keys()) != set(py_files.keys()):

--- a/tests/check-consistency-formats.py
+++ b/tests/check-consistency-formats.py
@@ -1,24 +1,19 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
-import sys
-from glob import glob
-import os.path as osp
-
-import yaml
-import jinja2
+# Imports
 import jsondiff
-import difflib
+import os
+import sys
+import yaml
+from glob import glob
 
 # function to extract name from file
-basename = lambda f: osp.splitext(osp.basename(f))[0]
-
+basename = lambda f: os.path.splitext(os.path.basename(f))[0]
 
 # load all paths keyed by their name
 spec_files = {basename(f): f for f in glob('specs/*.yaml')}
-jinja_templates = {basename(f): f for f in glob('specs/*.j2')}
 py_files = {basename(f): f for f in glob('lang/python/airr/specs/*.yaml')}
 r_files = {basename(f): f for f in glob('lang/R/inst/extdata/*.yaml')}
-doc_files = {basename(f): f for f in glob('docs/*.md')}
 
 # Check python package specs
 if set(spec_files.keys()) != set(py_files.keys()):
@@ -35,13 +30,6 @@ if set(spec_files.keys()) != set(r_files.keys()):
     for spec in set(r_files.keys()) - set(spec_files.keys()):
         print('{} found in R package but missing from specs/'.format(spec), file=sys.stderr)
     sys.exit(1)
-
-# Check doc rendering
-if len(set(spec_files.keys()) - set(doc_files.keys())) > 0:
-    for spec in set(spec_files.keys()) - set(doc_files.keys()):
-        print('{} missing from rendered doc files'.format(spec), file=sys.stderr)
-    sys.exit(1)
-
 
 for spec_name in spec_files:
     # check equality of specs
@@ -60,20 +48,7 @@ for spec_name in spec_files:
 
     # Check R package
     if jsondiff.diff(gold_spec, r_spec) != {}:
-        print('{} spec is different from python version'.format(spec_name), file=sys.stderr)
+        print('{} spec is different from R version'.format(spec_name), file=sys.stderr)
         print(jsondiff.diff(gold_spec, r_spec), file=sys.stderr)
         sys.exit(1)
 
-    # check that docs have been rendered
-    with open(jinja_templates[spec_name], 'r') as ip:
-        template = jinja2.Template(ip.read().strip())
-    with open(doc_files[spec_name], 'r') as ip:
-        doc_contents = ip.read().strip()
-
-    if template.render(gold_spec) != doc_contents:
-        doc_lines = doc_contents.splitlines()
-        gold_lines = template.render(gold_spec).splitlines()
-        diff = difflib.unified_diff(doc_lines, gold_lines)
-        print('rendered doc for {} does not correspond to spec'.format(spec_name))
-        print('\n'.join(diff))
-        sys.exit(1)

--- a/tests/check-consistency-miairr.py
+++ b/tests/check-consistency-miairr.py
@@ -1,13 +1,11 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
-import sys
 import csv
-from collections import Counter
-
-import yaml
 import pandas as pd
-from deepdiff import DeepDiff
-
+import sys
+import yaml
+from collections import Counter
+#from deepdiff import DeepDiff
 
 miairr_dataset_to_api_object = {
     '1 / study': 'Study',


### PR DESCRIPTION
1. Added autobuild of Rearrangements and Alignment TSVs to docs build.
2. Added `specs/miairr.yaml` with MiAIRR content of old TSV.
3. Made formats consistency check function (no refactor - just made it run.)
4. Moved consistency checks to `/tests`

Probably can't get back to this task for a bit (#29), so just want to merge what exists now for cleaner history.
