### PR TITLE
Python library bug fix - v1.2.1

### DIFF
--- a/lang/python/NEWS.rst
+++ b/lang/python/NEWS.rst
@@ -1,3 +1,9 @@
+Version 1.2.1:  October 5, 2018
+--------------------------------------------------------------------------------
+
++ Fixed a bug in the python reference library causing start coordinate values
+  to be empty in some cases when writing data.
+
 Version 1.2.0:  August 17, 2018
 --------------------------------------------------------------------------------
 

--- a/lang/python/airr/io.py
+++ b/lang/python/airr/io.py
@@ -218,7 +218,7 @@ class RearrangementWriter:
             # Adjust coordinates
             if f.endswith('_start') and self.base == 1:
                 try:
-                    row[f] = row[f] + 1
+                    row[f] = self.schema.to_int(row[f]) + 1
                 except TypeError:
                     row[f] = None
 


### PR DESCRIPTION
Fixed a bug with start coordinate conversion leading to empty values in the python library upon write from `airr.io.RearrangementWriter`.

Small change, but I think it justifies a patch release of the python library to PyPI (v1.2.1).