### PR TITLE
Issue 227

### DIFF
--- a/docs/api/overview.rst
+++ b/docs/api/overview.rst
@@ -177,7 +177,7 @@ The content of the JSON payload.
     "fields":["repertoire_id"]
   }
 
-The response contains two JSON objects, an ``Info`` object that provides information about the API response and a ``Repertoire`` object that contains the list of ``Repertoires`` that met the query search criteria. In this case, the query returns a list of five repertoire identifiers. Note the ``Info`` object is based on the ``info`` block as specified in the OpenAPI v2.0 specification.
+The response contains two JSON objects, an Info object that provides information about the API response and a Repertoire object that contains the list of Repertoires that met the query search criteria. In this case, the query returns a list of five repertoire identifiers. Note the Info object is based on the info block as specified in the OpenAPI v2.0 specification.
 
 .. code-block:: json
 

--- a/docs/api/overview.rst
+++ b/docs/api/overview.rst
@@ -177,19 +177,28 @@ The content of the JSON payload.
     "fields":["repertoire_id"]
   }
 
-The response contains a list of five repertoire identifiers.
+The response contains two JSON objects, an ``Info`` object that provides information about the API response and a ``Repertoire`` object that contains the list of ``Repertoires`` that met the query search criteria. In this case, the query returns a list of five repertoire identifiers. Note the ``Info`` object is based on the ``info`` block as specified in the OpenAPI v2.0 specification.
 
 .. code-block:: json
 
-  { "success":true,
-    "result": [
-      {"repertoire_id":"4357957907784536551-242ac11c-0001-012"},
-      {"repertoire_id":"4476756703191896551-242ac11c-0001-012"},
-      {"repertoire_id":"6205695788196696551-242ac11c-0001-012"},
-      {"repertoire_id":"6393557657723736551-242ac11c-0001-012"},
-      {"repertoire_id":"7158276584776536551-242ac11c-0001-012"}
+{
+    "Info": {
+        "title": "AIRR Data Commons API",
+        "description": "API response for repertoire query",
+        "version": 1.3,
+        "contact": {
+            "name": "AIRR Community",
+            "url": "https://github.com/airr-community"
+        }
+    },
+    "Repertoire": [
+        {"repertoire_id": "4357957907784536551-242ac11c-0001-012"},
+        {"repertoire_id": "4476756703191896551-242ac11c-0001-012"},
+        {"repertoire_id": "6205695788196696551-242ac11c-0001-012"},
+        {"repertoire_id": "6393557657723736551-242ac11c-0001-012"},
+        {"repertoire_id": "7158276584776536551-242ac11c-0001-012"}
     ]
-  }
+}
 
 .. __: https://github.com/airr-community/airr-standards/blob/master/lang/python/examples/query1-2_repertoire.json
 

--- a/docs/api/overview.rst
+++ b/docs/api/overview.rst
@@ -182,16 +182,19 @@ The response contains two JSON objects, an Info object that provides information
 .. code-block:: json
 
 {
-    "Info": {
+    "Info":
+    {
         "title": "AIRR Data Commons API",
         "description": "API response for repertoire query",
         "version": 1.3,
-        "contact": {
+        "contact":
+	{
             "name": "AIRR Community",
             "url": "https://github.com/airr-community"
         }
     },
-    "Repertoire": [
+    "Repertoire":
+    [
         {"repertoire_id": "4357957907784536551-242ac11c-0001-012"},
         {"repertoire_id": "4476756703191896551-242ac11c-0001-012"},
         {"repertoire_id": "6205695788196696551-242ac11c-0001-012"},

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -15,6 +15,7 @@ definitions:
   # Info object
   info_object:
     type: object
+    description: Provides information about the API response
     properties:
       title:
         type: string
@@ -43,13 +44,10 @@ definitions:
     type: object
     properties:
       Info:
-        type: object
-        description: Provides information about the API response
-        properties:
-          $ref: '#/definitions/info_object'
+        $ref: '#/definitions/info_object'
       Repertoire:
         $ref: '#/definitions/repertoire_list'
-
+          
   # list of rearrangement annotations
   rearrangement_list:
     type: array

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -59,8 +59,7 @@ definitions:
     type: object
     properties:
       Info:
-        type: object
-        description: Provides information about the API response
+        $ref: '#/definitions/info_object'
       Rearrangement:
         $ref: '#/definitions/rearrangement_list'
 

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -12,6 +12,20 @@ info:
 basePath: /airr/v1
 
 definitions:
+  # Info object
+  info_object:
+    type: object
+    properties:
+      title: string
+      version: string
+      description: string
+      contact: 
+        type: object
+        properties:
+          name: string
+          url: string
+          email: string
+
   # list of repertoires
   repertoire_list:
     type: array
@@ -25,6 +39,8 @@ definitions:
       Info:
         type: object
         description: Provides information about the API response
+        properties:
+          $ref: '#/definitions/info_object'
       Repertoire:
         $ref: '#/definitions/repertoire_list'
 

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -159,7 +159,7 @@ paths:
           description: |
             A successful call returns the repertoire data.
           schema:
-            $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Repertoire'
+            $ref: '#/definitions/repertoire_response'
         '400':
           description: Invalid repertoire ID supplied
         '404':
@@ -227,7 +227,7 @@ paths:
           description: >
             A successful call returns the rearrangement annotation data.
           schema:
-            $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Rearrangement'
+            $ref: '#/definitions/rearrangement_response'
         '400':
           description: Invalid rearrangement ID supplied
         '404':

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -16,15 +16,21 @@ definitions:
   info_object:
     type: object
     properties:
-      title: string
-      version: string
-      description: string
+      title:
+        type: string
+      version:
+        type: string
+      description:
+        type: string
       contact: 
         type: object
         properties:
-          name: string
-          url: string
-          email: string
+          name:
+            type: string
+          url:
+            type: string
+          email:
+            type: string
 
   # list of repertoires
   repertoire_list:


### PR DESCRIPTION
Fixes #227 - document updates
Fixes #228 - /repertoire, /repertoire/{id}, /rearrangement, and /rearrangement{id} now use consistent Info blocks (info block created in spec).
Fixes #225 - problem in docs with using wrong organism key.