### PR TITLE
revert locus_species until we resolve how to handle ontologies

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1427,29 +1427,6 @@ Rearrangement:
         locus:
             type: string
             description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
-        locus_species:
-            type: string
-            $ref: '#/Ontology'
-            description: >
-                Binomial designation of the species from which the locus originates. Typically, this value should be
-                identical to `organism`, if which case it SHOULD NOT be set explicitly. However, there are valid
-                experimental setups in which the two might differ, e.g. transgenic animal models. If set, this key
-                will overwrite the `organism` information for all lower layers of the schema.
-            example:
-                id: 9096
-                value: Homo sapiens
-            x-airr:
-                miairr: false
-                required: false
-                nullable: true
-                format: ontology
-                ontology:
-                    draft: false
-                    name: NCBITAXON
-                    url: https://www.ncbi.nlm.nih.gov/taxonomy
-                    top_node:
-                        id: 7776
-                        value: Gnathostomata
         v_call:
             type: string
             description: >

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1427,29 +1427,6 @@ Rearrangement:
         locus:
             type: string
             description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
-        locus_species:
-            type: string
-            $ref: '#/Ontology'
-            description: >
-                Binomial designation of the species from which the locus originates. Typically, this value should be
-                identical to `organism`, if which case it SHOULD NOT be set explicitly. However, there are valid
-                experimental setups in which the two might differ, e.g. transgenic animal models. If set, this key
-                will overwrite the `organism` information for all lower layers of the schema.
-            example:
-                id: 9096
-                value: Homo sapiens
-            x-airr:
-                miairr: false
-                required: false
-                nullable: true
-                format: ontology
-                ontology:
-                    draft: false
-                    name: NCBITAXON
-                    url: https://www.ncbi.nlm.nih.gov/taxonomy
-                    top_node:
-                        id: 7776
-                        value: Gnathostomata
         v_call:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1427,29 +1427,6 @@ Rearrangement:
         locus:
             type: string
             description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
-        locus_species:
-            type: string
-            $ref: '#/Ontology'
-            description: >
-                Binomial designation of the species from which the locus originates. Typically, this value should be
-                identical to `organism`, if which case it SHOULD NOT be set explicitly. However, there are valid
-                experimental setups in which the two might differ, e.g. transgenic animal models. If set, this key
-                will overwrite the `organism` information for all lower layers of the schema.
-            example:
-                id: 9096
-                value: Homo sapiens
-            x-airr:
-                miairr: false
-                required: false
-                nullable: true
-                format: ontology
-                ontology:
-                    draft: false
-                    name: NCBITAXON
-                    url: https://www.ncbi.nlm.nih.gov/taxonomy
-                    top_node:
-                        id: 7776
-                        value: Gnathostomata
         v_call:
             type: string
             description: >


### PR DESCRIPTION
in rearrangement schema. As we need to do a release soon, don't want this unresolved field in the schema as it may break existing code.