### PR TITLE
Extend the Junction AA description

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1597,8 +1597,7 @@ Rearrangement:
         junction_aa:
             type: string
             description: >
-                Junction region amino acid sequence, where the junction is defined as
-                the CDR3 plus the two flanking conserved codons.
+                Amino acid translation of the junction.
             example: CARAGVYDGYTMDYW
             x-airr:
                 miairr: true

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1545,7 +1545,8 @@ Rearrangement:
         junction_aa:
             type: string
             description: >
-                Junction region amino acid sequence.
+                Junction region amino acid sequence, where the junction is defined as
+                the CDR3 plus the two flanking conserved codons.
             example: CARAGVYDGYTMDYW
             x-airr:
                 miairr: true

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1597,8 +1597,7 @@ Rearrangement:
         junction_aa:
             type: string
             description: >
-                Junction region amino acid sequence, where the junction is defined as
-                the CDR3 plus the two flanking conserved codons.
+                Amino acid translation of the junction.
             example: CARAGVYDGYTMDYW
             x-airr:
                 miairr: true

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1545,7 +1545,8 @@ Rearrangement:
         junction_aa:
             type: string
             description: >
-                Junction region amino acid sequence.
+                Junction region amino acid sequence, where the junction is defined as
+                the CDR3 plus the two flanking conserved codons.
             example: CARAGVYDGYTMDYW
             x-airr:
                 miairr: true

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1597,8 +1597,7 @@ Rearrangement:
         junction_aa:
             type: string
             description: >
-                Junction region amino acid sequence, where the junction is defined as
-                the CDR3 plus the two flanking conserved codons.
+                Amino acid translation of the junction.
             example: CARAGVYDGYTMDYW
             x-airr:
                 miairr: true

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1545,7 +1545,8 @@ Rearrangement:
         junction_aa:
             type: string
             description: >
-                Junction region amino acid sequence.
+                Junction region amino acid sequence, where the junction is defined as
+                the CDR3 plus the two flanking conserved codons.
             example: CARAGVYDGYTMDYW
             x-airr:
                 miairr: true


### PR DESCRIPTION
The Junction NT description notes that the junction is the CDR3 plus the conserved codons. The Junction AA description should have a similar definition.

Simple change, should be able to merge right away...