### PR TITLE
draft of a changelog 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,5 +40,4 @@ Table of Contents
     Data Submission and Query <standards/data_submission>
     Software <standards/software>
     Community <standards/community>
-    Release Notes <standards/news>
     Glossary <appendix/terms>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,4 +40,5 @@ Table of Contents
     Data Submission and Query <standards/data_submission>
     Software <standards/software>
     Community <standards/community>
+    Release Notes <standards/news>
     Glossary <appendix/terms>

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -13,7 +13,7 @@ Under development (Version 1.3.0)
 
 **Current changes in the development branch.**
 
-+ Added ontobee as default source for ``ontologies``
++ Added ELI OBS as default source for ``ontologies``
  .. #296 by bussec was merged on Jan 4, 2020
 + Expanded description for ``pcr_target``
  .. #288 by bussec was merged on Dec 10, 2019

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -13,7 +13,7 @@ Under development (Version 1.3.0)
 
 **Current changes in the development branch.**
 
-+ Added ELI OBS as default source for ``ontologies``
++ Added EBI OLS as default source for ``ontologies``
  .. #296 by bussec was merged on Jan 4, 2020
 + Expanded description for ``pcr_target``
  .. #288 by bussec was merged on Dec 10, 2019

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -8,19 +8,19 @@ Release Notes
 ==============
 
 
-Version 1.2.?: current
+Version 1.?.?: current
 --------------------------------------------------------------------------------
 
++ Added ontobee as default source for ``ontologies``
+ .. #296 by bussec was merged on Jan 4, 2020
 + Expanded description for ``pcr_target``
- .. #288 by bussec was merged on Dec 10, 2018
+ .. #288 by bussec was merged on Dec 10, 2019
 + Fix capitalization of ``age_unit`` description
- .. #290 by bcorrie was merged on Dec 10, 2018
+ .. #290 by bcorrie was merged on Dec 10, 2019
 + Fix name: fields for ``age`` fields
- .. #285 by bcorrie was merged on Nov 27, 2018
-+ Reverted ``locus_species`` until we resolve how to handle ontologies
- .. #281 by schristley was merged on Nov 24, 2018
-+ Added species information to ``cell_subset`` and ``locus`` fields
- .. #260 by bussec was merged on Nov 8
+ .. #285 by bcorrie was merged on Nov 27, 2019
++ Introduced ``cell_species``
+ .. #260 by bussec was merged on Nov 8, 2019; #281 Reverted ``locus_species``  by bcorrie was merged on Nov 27, 2019
 + Added ``sample_processing_id``
  .. #263 by schristley was merged on Oct 21
 + Added vocabularies/ontologies as JSON string for: Cell subset, Target substrate, Library generation method, Complete sequences, Physical linkage of different loci

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -1,0 +1,106 @@
+.. this Changelog is based on the merged pull requests involving the ````airr-schema.yaml```` file since Jan 9 2018
+
+.. toctree::
+   :maxdepth: 1
+   :caption:  AIRR Standards Release Notes
+
+Release Notes
+==============
+
+
+Version 1.2.?: current
+--------------------------------------------------------------------------------
+
++ Expanded description for ``pcr_target``
+ .. #288 by bussec was merged on Dec 10, 2018
++ Fix capitalization of ``age_unit`` description
+ .. #290 by bcorrie was merged on Dec 10, 2018
++ Fix name: fields for ``age`` fields
+ .. #285 by bcorrie was merged on Nov 27, 2018
++ Reverted ``locus_species`` until we resolve how to handle ontologies
+ .. #281 by schristley was merged on Nov 24, 2018
++ Added species information to ``cell_subset`` and ``locus`` fields
+ .. #260 by bussec was merged on Nov 8
++ Added ``sample_processing_id``
+ .. #263 by schristley was merged on Oct 21
++ Added vocabularies/ontologies as JSON string for: Cell subset, Target substrate, Library generation method, Complete sequences, Physical linkage of different loci
+ .. #155 by bussec was merged on Oct 16, 2018 • Approved
++ Include format JSON string
+ .. #155 by bussec was merged on Oct 16, 2018 • Approved
++ Introduced age ranges, ``age_min``, ``age_max``, and ``age_unit``
+ .. #254 by franasa was merged on Oct 11 • Approved
++ Updated schema with more concise vdj call descriptions
+ .. #257 by bcorrie was merged on Oct 7 • Approved
+
+Version 1.2.1: Oct 5, 2018
+--------------------------------------------------------------------------------
+
++ Schema gene vs segment terminology corrections
+ .. #153 by javh was merged on Sep 13 • Approved
++ Added ``Info`` object
+ .. #150 by schristley was merged on Aug 28
++ Updated ``cell_subset`` URL in AIRR schema
+ .. #221 by bussec was merged on Aug 7
+
+Version 1.2.0: Aug 18, 2018
+--------------------------------------------------------------------------------
+
++ Removed foreign 'study_id' fields
+ .. #134 by schristley was merged on Jul 12
++ Introduced ``keywords_study`` field
+ .. #200 by bussec was merged on Jun 13 • Approved
+
+Version 1.1.0: May 3, 2018
+--------------------------------------------------------------------------------
+
++ Added ``required`` and ``nullable`` constrains to AIRR schema
+ .. #182 by bussec was merged on Apr 1 • Approved
++ Schema definitions for MiAIRR attributes and ontology
+ .. #182 by bussec was merged on Apr 1 • Approved
++ Introduction of an ``x-airr`` object indicating if field is required by MiAIRR
+ .. #182 by bussec was merged on Apr 1 • Approved
++ Rename ``rearrangement_set_id`` to ``data_processing_id``
+ .. #182 by bussec was merged on Apr 1 • Approved
++ Rename ``study_description`` to ``study_type``
+ .. #182 by bussec was merged on Apr 1 • Approved
++ Added ``physical quantity`` format
+ .. #182 by bussec was merged on Apr 1 • Approved
++ Raw sequencing files into separate schema object
+ .. #182 by bussec was merged on Apr 1 • Approved
++ Rename Attributes object
+ .. #182 by bussec was merged on Apr 1 • Approved
++ Added ``primary_annotation`` and ``repertoire_id``
+ .. #156 by schristley was merged on Mar 4 • Approved
++ Added ``diagnosis`` to repertoire object
+ .. #156 by schristley was merged on Mar 4 • Approved
++ Added ontology for ``organism``
+ .. #156 by schristley was merged on Mar 4 • Approved
++ Added more detailed specification of ``sequencing_run``, ``repertoire`` and ``rearrangement``
+ .. #156 by schristley was merged on Mar 4 • Approved
++ Added repertoire schema
+ .. #156 by schristley was merged on Mar 4 • Approved
++ Rename ``definitions.yaml`` to ``airr-schema.yaml``
+ .. #66. in progress .. #124 by javh was merged on Apr 20
++ Removed c_call, c_score and c_cigar from required as this is not typical reference aligner output
+ .. #106 by javh was merged on Apr 18, 2018
++ Renamed vdj_score, vdj_identity, vdj_evalue, and vdj_cigar to ``score``, ``identity``, ``evalue``, and ``cigar``
+ .. #106 by javh was merged on Apr 18, 2018
++ Added missing ``c_identity`` and ``c_evalue`` fields to Rearrangements spec
+ .. #94 on Mar 22, 2018
++ Swapped order of N and S operators in CIGAR string
+ .. #94 on Mar 22, 2018
++ Some description clean up for consistency in Rearrangement spec
+ .. #94 on Mar 22, 2018
++ Remove repeated objects in ``definitions.yaml``
+ .. #78 on Jan 26, 2018 #53
++ Added Alignment object to ``definitions.yaml``
+ .. #78 on Jan 26, 2018 #67
++ Updated MiARR-Formats consistency check TSV with junction change
+ .. #75 on Jan 9, 2018. also: #84, #85, #89
++ Changed definition from functional to productive
+ .. #75 on Jan 9, 2018. also: #84,. #85,. #89
+
+
+Version 1.0.1: Jan 9, 2018
+--------------------------------------------------------------------------------
+

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -11,7 +11,7 @@ Release Notes
 Under development (Version 1.3.0)
 --------------------------------------------------------------------------------
 
-Current changes in the development branch. When released, will include the
+**Current changes in the development branch.**
 
 + Added ontobee as default source for ``ontologies``
  .. #296 by bussec was merged on Jan 4, 2020
@@ -37,7 +37,7 @@ Current changes in the development branch. When released, will include the
 Version 1.2.1: Oct 5, 2018
 --------------------------------------------------------------------------------
 
-Minor patch release.
+**Minor patch release.**
 
 + Schema gene vs segment terminology corrections
  .. #153 by javh was merged on Sep 13 • Approved
@@ -49,7 +49,7 @@ Minor patch release.
 Version 1.2.0: Aug 18, 2018
 --------------------------------------------------------------------------------
 
-Peer reviewed released of the Rearrangement schema.
+**Peer reviewed released of the Rearrangement schema.**
 
 + Definition change for the coordinate fields of the Rearrangement and Alignment schema.
   Coordinates are now defined as 1-based closed intervals, instead of 0-based half-open
@@ -62,7 +62,7 @@ Peer reviewed released of the Rearrangement schema.
 Version 1.1.0: May 3, 2018
 --------------------------------------------------------------------------------
 
-Initial public released of the Rearrangement and Alignment schemas.
+**Initial public released of the Rearrangement and Alignment schemas.**
 
 + Added ``required`` and ``nullable`` constrains to AIRR schema.
  .. #182 by bussec was merged on Apr 1 • Approved
@@ -116,4 +116,4 @@ Initial public released of the Rearrangement and Alignment schemas.
 Version 1.0.1: Jan 9, 2018
 --------------------------------------------------------------------------------
 
-MiAIRR v1 official release and initial draft of Rearrangement and Alignment schemas.
+**MiAIRR v1 official release and initial draft of Rearrangement and Alignment schemas.**

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -8,8 +8,10 @@ Release Notes
 ==============
 
 
-Version 1.?.?: current
+Under development (Version 1.3.0)
 --------------------------------------------------------------------------------
+
+Current changes in the development branch. When released, will include the
 
 + Added ontobee as default source for ``ontologies``
  .. #296 by bussec was merged on Jan 4, 2020
@@ -17,7 +19,7 @@ Version 1.?.?: current
  .. #288 by bussec was merged on Dec 10, 2019
 + Fix capitalization of ``age_unit`` description
  .. #290 by bcorrie was merged on Dec 10, 2019
-+ Fix name: fields for ``age`` fields
++ Fix name of ``age`` fields
  .. #285 by bcorrie was merged on Nov 27, 2019
 + Introduced ``cell_species``
  .. #260 by bussec was merged on Nov 8, 2019; #281 Reverted ``locus_species``  by bcorrie was merged on Nov 27, 2019
@@ -29,11 +31,13 @@ Version 1.?.?: current
  .. #155 by bussec was merged on Oct 16, 2018 • Approved
 + Introduced age ranges, ``age_min``, ``age_max``, and ``age_unit``
  .. #254 by franasa was merged on Oct 11 • Approved
-+ Updated schema with more concise vdj call descriptions
++ Updated schema with more concise VDJ call descriptions
  .. #257 by bcorrie was merged on Oct 7 • Approved
 
 Version 1.2.1: Oct 5, 2018
 --------------------------------------------------------------------------------
+
+Minor patch release.
 
 + Schema gene vs segment terminology corrections
  .. #153 by javh was merged on Sep 13 • Approved
@@ -45,7 +49,12 @@ Version 1.2.1: Oct 5, 2018
 Version 1.2.0: Aug 18, 2018
 --------------------------------------------------------------------------------
 
-+ Removed foreign 'study_id' fields
+Peer reviewed released of the Rearrangement schema.
+
++ Definition change for the coordinate fields of the Rearrangement and Alignment schema.
+  Coordinates are now defined as 1-based closed intervals, instead of 0-based half-open
+  intervals (as previously defined in v1.1 of the schema).
++ Removed foreign ``study_id`` fields
  .. #134 by schristley was merged on Jul 12
 + Introduced ``keywords_study`` field
  .. #200 by bussec was merged on Jun 13 • Approved
@@ -53,9 +62,11 @@ Version 1.2.0: Aug 18, 2018
 Version 1.1.0: May 3, 2018
 --------------------------------------------------------------------------------
 
-+ Added ``required`` and ``nullable`` constrains to AIRR schema
+Initial public released of the Rearrangement and Alignment schemas.
+
++ Added ``required`` and ``nullable`` constrains to AIRR schema.
  .. #182 by bussec was merged on Apr 1 • Approved
-+ Schema definitions for MiAIRR attributes and ontology
++ Schema definitions for MiAIRR attributes and ontology.
  .. #182 by bussec was merged on Apr 1 • Approved
 + Introduction of an ``x-airr`` object indicating if field is required by MiAIRR
  .. #182 by bussec was merged on Apr 1 • Approved
@@ -63,7 +74,7 @@ Version 1.1.0: May 3, 2018
  .. #182 by bussec was merged on Apr 1 • Approved
 + Rename ``study_description`` to ``study_type``
  .. #182 by bussec was merged on Apr 1 • Approved
-+ Added ``physical quantity`` format
++ Added ``physical_quantity`` format
  .. #182 by bussec was merged on Apr 1 • Approved
 + Raw sequencing files into separate schema object
  .. #182 by bussec was merged on Apr 1 • Approved
@@ -81,26 +92,28 @@ Version 1.1.0: May 3, 2018
  .. #156 by schristley was merged on Mar 4 • Approved
 + Rename ``definitions.yaml`` to ``airr-schema.yaml``
  .. #66. in progress .. #124 by javh was merged on Apr 20
-+ Removed c_call, c_score and c_cigar from required as this is not typical reference aligner output
++ Removed ``c_call``, ``c_score`` and ``c_cigar`` from required as this is not
+  typical reference aligner output
  .. #106 by javh was merged on Apr 18, 2018
-+ Renamed vdj_score, vdj_identity, vdj_evalue, and vdj_cigar to ``score``, ``identity``, ``evalue``, and ``cigar``
++ Renamed ``vdj_score``, ``vdj_identity``, ``vdj_evalue``, and ``vdj_cigar`` to ``score``,
+  ``identity``, ``evalue``, and ``cigar``
  .. #106 by javh was merged on Apr 18, 2018
-+ Added missing ``c_identity`` and ``c_evalue`` fields to Rearrangements spec
++ Added missing ``c_identity`` and ``c_evalue`` fields to ``Rearrangement`` spec
  .. #94 on Mar 22, 2018
-+ Swapped order of N and S operators in CIGAR string
++ Swapped order of `N` and `S` operators in CIGAR string
  .. #94 on Mar 22, 2018
-+ Some description clean up for consistency in Rearrangement spec
++ Some description clean up for consistency in ``Rearrangement`` spec
  .. #94 on Mar 22, 2018
 + Remove repeated objects in ``definitions.yaml``
  .. #78 on Jan 26, 2018 #53
-+ Added Alignment object to ``definitions.yaml``
++ Added ``Alignment`` object to ``definitions.yaml``
  .. #78 on Jan 26, 2018 #67
-+ Updated MiARR-Formats consistency check TSV with junction change
++ Updated MiARR format consistency check TSV with junction change
  .. #75 on Jan 9, 2018. also: #84, #85, #89
 + Changed definition from functional to productive
  .. #75 on Jan 9, 2018. also: #84,. #85,. #89
 
-
 Version 1.0.1: Jan 9, 2018
 --------------------------------------------------------------------------------
 
+MiAIRR v1 official release and initial draft of Rearrangement and Alignment schemas.

--- a/docs/standards/overview.rst
+++ b/docs/standards/overview.rst
@@ -14,4 +14,4 @@ Information about all of the AIRR Community standards.
    AIRR Data Representations <../datarep/overview>
    Software Guidelines <../swtools/airr_swtools_standard>
    AIRR Data Commons API <../api/adc_api>
-   
+   Schema Release Notes <news>


### PR DESCRIPTION
Fixes #286
 
I've been playing a bit around with Sphinx so I made this draft for a changelog for your review. 
The file was created based on the merged PR's involving the ````airr-schema.yaml```` file since Jan 9 2018 (Version 1.0.1). I am not 100 % sure how this is stored in the docs as @javh mention. I tried to render this to see an example but was unsuccesful: 

>  Same thing we do for the software packages:
https://raw.githubusercontent.com/airr-community/airr-standards/master/docs/packages/airr-python/news.rst

So for now I added it to the index.rst file, I've also left as comments of the raw ``news.rst`` the PR's tags of the changes made in case you would like to keep them or store them elsewhere,  if so let me know how would it be.

Also, I did not address @schristley's last point, so it is still an open issue: 

> We need some additional documentation to clarify the overlap/difference between minimal information (MiAIRR, study reporting) and required schema fields (Rearrangement schema, tool interoperability) to users. This is currently confusing.


