### PR TITLE
Fields for IMGT support

### DIFF
--- a/docs/api/adc_api.rst
+++ b/docs/api/adc_api.rst
@@ -758,7 +758,7 @@ in the AIRR Schema.
       - Description
     * - rearrangement_id, repertoire_id, sample_processing_id, data_processing_id, clone_id, cell_id, pair_id
       - Identifiers; rearrangement_id allows for query of that specific rearrangement object in the repository, while repertoire_id, sample_processing_id, and data_processing_id are links to the repertoire metadata for the rearrangement. The clone_id, cell_id, and pair_id are all identifiers that group rearrangements based on clone definition, single cell assignment, and paired chain linking.
-    * - locus, v_call, d_call, j_call, c_call, productive, junction_aa, junction_aa_length
+    * - locus, v_call, d_call, j_call, c_call, v_gene, d_gene, j_gene, c_gene, v_subgroup, d_subgroup, j_subgroup, c_subgroup, productive, junction_aa, junction_aa_length
       - Commonly used rearrangement annotations.
 
 **Repertoire/rearrangement object size**

--- a/docs/api/adc_api.rst
+++ b/docs/api/adc_api.rst
@@ -758,7 +758,7 @@ in the AIRR Schema.
       - Description
     * - rearrangement_id, repertoire_id, sample_processing_id, data_processing_id, clone_id, cell_id, pair_id
       - Identifiers; rearrangement_id allows for query of that specific rearrangement object in the repository, while repertoire_id, sample_processing_id, and data_processing_id are links to the repertoire metadata for the rearrangement. The clone_id, cell_id, and pair_id are all identifiers that group rearrangements based on clone definition, single cell assignment, and paired chain linking.
-    * - locus, v_call, d_call, j_call, c_call, v_gene, d_gene, j_gene, c_gene, v_subgroup, d_subgroup, j_subgroup, c_subgroup, productive, junction_aa, junction_aa_length
+    * - locus, v_call, d_call, j_call, c_call, productive, junction_aa, junction_aa_length
       - Commonly used rearrangement annotations.
 
 **Repertoire/rearrangement object size**

--- a/docs/datarep/alignments.rst
+++ b/docs/datarep/alignments.rst
@@ -4,7 +4,7 @@ Alignment Schema (Experimental)
 ===============================
 
 An Alignment is the output from a V(D)J assignment process for a
-single V, D, J, or C gene segment for a sequence. It is not necessary
+single V, D, J, or C gene for a sequence. It is not necessary
 that the V(D)J assignment process performs a sequence alignment
 algorithm, as the schema can support any algorithmic process. Multiple
 Alignment records are supported and expected for a single sequence

--- a/docs/datarep/rearrangements.rst
+++ b/docs/datarep/rearrangements.rst
@@ -68,9 +68,26 @@ be the set: IGH, IGK, IGL, TRA, TRB, TRD, or TRG.
 **Gene and allele names**
 
 Gene call examples use the IMGT nomenclature, but no specific gene or allele
-nomenclature is mandated. Species denotations may or may not be included in the
+nomenclature is strictly mandated. Species denotations may or may not be included in the
 gene name, as appropriate. For example, "Homo sapiens IGHV4-59*01", "IGHV4-59*01" and
 "AB019438" are all valid entries for the same allele.
+
+However, when using an established reference database to assign gene calls then
+adherence to the exact nomenclature used by the reference database is strongly
+recommended, as this will faciliate mapping to the database entries, cross-study
+comparison, and upload to public repositories.
+
+Lymphocyte receptor genes and alleles are assigned by the Immunoglobulins,
+T cell Receptors and Major Histocompatibility Nomenclature Subcommittee of the
+International Union of Immunological Societies (IUIS) and managed by
+`IMGT <http://www.imgt.org/IMGTrepertoire>`__. If a gene is listed in this system,
+the name allocated by IUIS should be used. Where a gene is not listed in this system,
+implementors should choose a suitable naming scheme, taking care to ensure that the
+names are easily distinguishable from IUIS names and are unlikely to clash with
+IUIS names allocated in the future. To ensure correct naming of identified genes,
+the use of a reference set such as the `IMGT reference data
+<http://www.imgt.org/vquest/refseqh.html>`_ is recommended and the
+reference set should be regularly updated.
 
 **Alignments**
 

--- a/docs/datarep/rearrangements.rst
+++ b/docs/datarep/rearrangements.rst
@@ -72,22 +72,10 @@ nomenclature is strictly mandated. Species denotations may or may not be include
 gene name, as appropriate. For example, "Homo sapiens IGHV4-59*01", "IGHV4-59*01" and
 "AB019438" are all valid entries for the same allele.
 
-However, when using an established reference database to assign gene calls then
+However, when using an established reference database to assign gene calls
 adherence to the exact nomenclature used by the reference database is strongly
-recommended, as this will faciliate mapping to the database entries, cross-study
+recommended, as this will facilitate mapping to the database entries, cross-study
 comparison, and upload to public repositories.
-
-Lymphocyte receptor genes and alleles are assigned by the Immunoglobulins,
-T cell Receptors and Major Histocompatibility Nomenclature Subcommittee of the
-International Union of Immunological Societies (IUIS) and managed by
-`IMGT <http://www.imgt.org/IMGTrepertoire>`__. If a gene is listed in this system,
-the name allocated by IUIS should be used. Where a gene is not listed in this system,
-implementors should choose a suitable naming scheme, taking care to ensure that the
-names are easily distinguishable from IUIS names and are unlikely to clash with
-IUIS names allocated in the future. To ensure correct naming of identified genes,
-the use of a reference set such as the `IMGT reference data
-<http://www.imgt.org/vquest/refseqh.html>`_ is recommended and the
-reference set should be regularly updated.
 
 **Alignments**
 

--- a/docs/miairr/vdjserver.rst
+++ b/docs/miairr/vdjserver.rst
@@ -6,7 +6,7 @@ Introduction to VDJServer
 
 VDJServer is a cloud-based analysis portal for immune repertoire sequence data that
 provides access to a suite of tools for a complete analysis workflow, including modules
-for preprocessing and quality control of sequence reads, V(D)J gene segment assignment,
+for preprocessing and quality control of sequence reads, V(D)J gene assignment,
 repertoire characterization, and repertoire comparison. VDJServer also provides
 sophisticated visualizations for exploratory analysis. It is accessible through a standard
 web browser via a graphical user interface designed for use by immunologists, clinicians,

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1360,7 +1360,7 @@ Alignment:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
         data_processing_id:
             type: string
             description: >
@@ -1453,7 +1453,7 @@ Rearrangement:
                 - TRD
                 - TRG
             description: >
-                Gene locus (chain type). Note that this field uses a controlled vocubulary that is meant to provide a
+                Gene locus (chain type). Note that this field uses a controlled vocabulary that is meant to provide a
                 generic classification of the locus, not necessarily the correct designation according to a specific
                 nomenclature.
             example: IGH
@@ -2393,7 +2393,7 @@ Rearrangement:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
             x-airr:
                 miairr: false
                 required: true

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1641,9 +1641,9 @@ Rearrangement:
         c_call:
             type: string
             description: >
-                C region gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHM*01).
-            example: IGHM*01
+                Constant region gene with allele. If referring to a known reference sequence in a database, such as
+                IMGT/GENE-DB, the relevant gene/allele nomenclature should be followed (e.g., IGHG1*01).
+            example: IGHG1*01
             x-airr:
                 miairr: true
                 required: true
@@ -1654,9 +1654,10 @@ Rearrangement:
         c_subgroup:
             type: string
             description: >
-                C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHM).
-            example: IGHM
+                Subgroup of the constant region gene. For immunoglobulins, this should be informative of the isotype
+                (e.g,, IgG). If referring to a known reference sequence in a database, such as IMGT/GENE-DB, the
+                relevant gene nomenclature should be followed (e.g., IGHG).
+            example: IGHG
             x-airr:
                 miairr: false
                 required: true
@@ -1666,9 +1667,12 @@ Rearrangement:
         c_gene:
             type: string
             description: >
-                C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHM).
-            example: IGHM
+                Constant region gene. For immunoglobulins, this should be informative about the subclass, if it exists
+                for the given isotype (e.g., IgG1 for IgG). In cases in which it is contested whether a sequence
+                constitutes a gene or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be
+                encoded as gene, not as allele (i.e., here, not in c_allele). If referring to a known reference sequence
+                in a database, such as IMGT/GENE-DB, the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
             x-airr:
                 miairr: false
                 required: true
@@ -1678,8 +1682,10 @@ Rearrangement:
         c_allele:
             type: string
             description: >
-                C allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHM*01 an allele
+                Allele of constant region gene. In cases in which it is contested whether a sequence constitutes a gene
+                or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be encoded as gene, not as
+                allele (i.e., not here, but in c_gene). If referring to a known reference sequence in a database, such
+                as IMGT/GENE-DB, the relevant gene nomenclature should be followed. For example, for IGHG1*01 an allele
                 string of 01 should be used (not 1).
             example: 01
             x-airr:

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -927,7 +927,12 @@ NucleicAcidProcessing:
                 name: Protocol IDs
         pcr_target:
             type: array
-            description: Target locus information
+            description: >
+                If a PCR step was performed that specifically targets the IG/TR loci, the target and primer locations
+                need to be provided here. This field holds an array of PCRTarget objects, so that multiplex PCR setups
+                amplifying multiple loci at the same time can be annotated using one record per locus. PCR setups not
+                targeting any specific locus must not annotate this field but select the appropriate 
+                library_generation_method instead.
             items:
                 $ref: '#/PCRTarget'
         complete_sequences:

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1444,6 +1444,13 @@ Rearrangement:
         locus:
             type: string
             description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
+            example: IGH
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: Locus
         v_call:
             type: string
             description: >
@@ -1456,7 +1463,44 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
+                name: V gene with allele
+        v_subgroup:
+            type: string
+            description: >
+                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4).
+            example: IGHV4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: V gene subgroup
+        v_gene:
+            type: string
+            description: >
+                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+            example: IGHV4-59
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
                 name: V gene
+        v_allele:
+            type: string
+            description: >
+                V allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHV4-59*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: V allele
         d_call:
             type: string
             description: >
@@ -1469,7 +1513,44 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
+                name: D gene with allele
+        d_subgroup:
+            type: string
+            description: >
+                D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: D gene subgroup
+        d_gene:
+            type: string
+            description: >
+                D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
                 name: D gene
+        d_allele:
+            type: string
+            description: >
+                D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: D allele
         j_call:
             type: string
             description: >
@@ -1482,7 +1563,44 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
+                name: J gene with allele
+        j_subgroup:
+            type: string
+            description: >
+                J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: J gene subgroup
+        j_gene:
+            type: string
+            description: >
+                J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
                 name: J gene
+        j_allele:
+            type: string
+            description: >
+                J allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHJ4*02 an allele
+                string of 02 should be used (not 1).
+            example: 02
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: J allele
         c_call:
             type: string
             description: >
@@ -1496,6 +1614,43 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: C region
+        c_subgroup:
+            type: string
+            description: >
+                C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHM).
+            example: IGHM
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C gene subgroup
+        c_gene:
+            type: string
+            description: >
+                C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHM).
+            example: IGHM
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C gene
+        c_allele:
+            type: string
+            description: >
+                C allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHM*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C allele
         sequence_alignment:
             type: string
             description: >

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -946,8 +946,8 @@ NucleicAcidProcessing:
                 - "complete+untemplated"
             description: >
                 To be considered `complete`, the procedure used for library construction MUST generate sequences that
-                1) include the first V segment codon that encodes the mature polypeptide chain (i.e. after the
-                leader sequence) and 2) include the last complete codon of the J segment (i.e. 1 bp 5' of the J->C
+                1) include the first V gene codon that encodes the mature polypeptide chain (i.e. after the
+                leader sequence) and 2) include the last complete codon of the J gene (i.e. 1 bp 5' of the J->C
                 splice site) and 3) provide sequence information for all positions between 1) and 2). To be considered
                 `complete & untemplated`, the sections of the sequences defined in points 1) to 3) of the previous
                 sentence MUST be untemplated, i.e. MUST NOT overlap with the primers used in library preparation.
@@ -1434,7 +1434,7 @@ Rearrangement:
                 True if the V(D)J sequence is predicted to be productive.
         vj_in_frame:
             type: boolean
-            description: True if the V and J segment alignments are in-frame.
+            description: True if the V and J gene alignments are in-frame.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1589,8 +1589,8 @@ Rearrangement:
         np1:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the V segment and first D segment
-                or between the V and J segments.
+                Nucleotide sequence of the combined N/P region between the V gene and
+                first D gene alignment or between the V gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1604,8 +1604,8 @@ Rearrangement:
         np2:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between either the first D and J segments
-                or the first D and second D segments.
+                Nucleotide sequence of the combined N/P region between either the first D gene and J gene
+                alignments or the first D gene and second D gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1619,7 +1619,8 @@ Rearrangement:
         np3:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the second D segment and J segment.
+                Nucleotide sequence of the combined N/P region between the second D gene
+                and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1770,7 +1771,7 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the first or only D segment as defined by the alignment tool.
+                support for the first or only D gene as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1796,7 +1797,7 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the second D segment as defined by the alignment tool.
+                support for the second D gene as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1861,14 +1862,14 @@ Rearrangement:
         v_sequence_start:
             type: integer
             description: >
-                Start position of the V segment in the query sequence (1-based closed interval).
+                Start position of the V gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         v_sequence_end:
             type: integer
             description: >
-                End position of the V segment in the query sequence (1-based closed interval).
+                End position of the V gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1889,30 +1890,32 @@ Rearrangement:
         v_alignment_start:
             type: integer
             description: >
-                Start position in the V segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         v_alignment_end:
             type: integer
             description: >
-                End position in the V segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_start:
             type: integer
             description: >
-                Start position of the first or only D segment in the query sequence (1-based closed interval).
+                Start position of the first or only D gene in the query sequence.
+                (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_end:
             type: integer
             description: >
-                End position of the first or only D segment in the query sequence (1-based closed interval).
+                End position of the first or only D gene in the query sequence.
+                (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1920,7 +1923,7 @@ Rearrangement:
             type: integer
             description: >
                 Alignment start position in the D gene reference sequence for the first or only
-                D segment (1-based closed interval).
+                D gene (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1928,14 +1931,14 @@ Rearrangement:
             type: integer
             description: >
                 Alignment end position in the D gene reference sequence for the first or only
-                D segment (1-based closed interval).
+                D gene (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_start:
             type: integer
             description: >
-                Start position of the first or only D segment in both the sequence_alignment
+                Start position of the first or only D gene in both the sequence_alignment
                 and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
@@ -1943,7 +1946,7 @@ Rearrangement:
         d_alignment_end:
             type: integer
             description: >
-                End position of the first or only D segment in both the sequence_alignment
+                End position of the first or only D gene in both the sequence_alignment
                 and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
@@ -1951,14 +1954,14 @@ Rearrangement:
         d2_sequence_start:
             type: integer
             description: >
-                Start position of the second D segment in the query sequence (1-based closed interval).
+                Start position of the second D gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d2_sequence_end:
             type: integer
             description: >
-                End position of the second D segment in the query sequence (1-based closed interval).
+                End position of the second D gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1979,30 +1982,30 @@ Rearrangement:
         d2_alignment_start:
             type: integer
             description: >
-                Start position of the second D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the second D gene alignment in both the sequence_alignment and
+                germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d2_alignment_end:
             type: integer
             description: >
-                End position of the second D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the second D gene alignment in both the sequence_alignment and
+                germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_sequence_start:
             type: integer
             description: >
-                Start position of the J segment in the query sequence (1-based closed interval).
+                Start position of the J gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_sequence_end:
             type: integer
             description: >
-                End position of the J segment in the query sequence (1-based closed interval).
+                End position of the J gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2023,16 +2026,16 @@ Rearrangement:
         j_alignment_start:
             type: integer
             description: >
-                Start position of the J segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_alignment_end:
             type: integer
             description: >
-                End position of the J segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2123,7 +2126,7 @@ Rearrangement:
         v_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the V segment, including any
+                Aligned portion of query sequence assigned to the V gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2138,7 +2141,7 @@ Rearrangement:
         d_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the D segment, including any
+                Aligned portion of query sequence assigned to the first or only D gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2150,10 +2153,25 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        d2_sequence_alignment:
+            type: string
+            description: >
+                Aligned portion of query sequence assigned to the second D gene, including any
+                indel corrections or numbering spacers.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of the d2_sequence_alignment field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the J segment, including any
+                Aligned portion of query sequence assigned to the J gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2212,6 +2230,22 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        d2_germline_alignment:
+            type: string
+            description: >
+                Aligned D gene germline sequence spanning the same region
+                as the d2_sequence_alignment field and including the same set
+                of corrections and spacers (if any).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of the d2_germline_alignment field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_germline_alignment:
             type: string
             description: >
@@ -2259,77 +2293,77 @@ Rearrangement:
         np1_length:
             type: integer
             description: >
-                Number of nucleotides between the V and first D segment or between
-                the V and J segments.
+                Number of nucleotides between the V gene and first D gene alignments or
+                between the V gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np2_length:
             type: integer
             description: >
-                Number of nucleotides between either the first D and J segments
-                or the first D and second D segments.
+                Number of nucleotides between either the first D gene and J gene alignments
+                or the first D gene and second D gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np3_length:
             type: integer
             description: >
-                Number of nucleotides between the second D segment and J segment.
+                Number of nucleotides between the second D gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n1_length:
             type: integer
-            description: Number of untemplated nucleotides 5' of the first or only D segment.
+            description: Number of untemplated nucleotides 5' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n2_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the first or only D segment.
+            description: Number of untemplated nucleotides 3' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n3_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the second D segment.
+            description: Number of untemplated nucleotides 3' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3v_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the V segment.
+            description: Number of palindromic nucleotides 3' of the V gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5d_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the first or only D segment.
+            description: Number of palindromic nucleotides 5' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the first or only D segment.
+            description: Number of palindromic nucleotides 3' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5d2_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the second D segment.
+            description: Number of palindromic nucleotides 5' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d2_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the second D segment.
+            description: Number of palindromic nucleotides 3' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5j_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the J segment.
+            description: Number of palindromic nucleotides 5' of the J gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2439,3 +2473,244 @@ Rearrangement:
             example: ENSEMBL, Homo sapiens build 90, 2017-10-01
             x-airr:
                 deprecated: true
+
+# A unique inferred clone object that has been constructed within a single data processing
+# for a single repertoire and a subset of its sequences and/or rearrangements.
+Clone:
+    discriminator: AIRR
+    type: object
+    required:
+        - clone_id
+        - repertoire_id
+        - germline_alignment
+    properties:
+        clone_id:
+            type: string
+            description: Identifier for the clone.
+            x-airr:
+                miairr: false
+                required: true
+        repertoire_id:
+            type: string
+            description: Identifier to the associated repertoire in study metadata.
+            x-airr:
+                miairr: false
+                required: true
+        data_processing_id:
+            type: string
+            description: Identifier of the data processing object in the repertoire metadata for this clone.
+            x-airr:
+                miairr: false
+                required: false
+        sequences:
+            type: array
+            items:
+                type: string
+            description: List of sequence_ids that are members of the clone.
+            x-airr:
+                miairr: false
+        rearrangements:
+            type: array
+            items:
+                type: string
+            description: List of rearrangement_ids that are members of the clone.
+            x-airr:
+                miairr: false
+        v_call:
+            type: string
+            description: >
+                V gene with allele of the inferred ancestral of the clone. For example, IGHV4-59*01.
+            example: IGHV4-59*01
+            x-airr:
+                miairr: false
+        d_call:
+            type: string
+            description: >
+                D gene with allele of the inferred ancestor of the clone. For example, IGHD3-10*01.
+            example: IGHD3-10*01
+            x-airr:
+                miairr: false
+        j_call:
+            type: string
+            description: >
+                J gene with allele of the inferred ancestor of the clone. For example, IGHJ4*02.
+            example: IGHJ4*02
+            x-airr:
+                miairr: false
+        junction:
+            type: string
+            description: >
+                Nucleotide sequence for the junction region of the inferred ancestor of the clone,
+                where the junction is defined as the CDR3 plus the two flanking conserved codons.
+        junction_aa:
+            type: string
+            description: >
+                Amino acid translation of the junction.
+            x-airr:
+                miairr: false
+        junction_length:
+            type: integer
+            description: Number of nucleotides in the junction.
+            x-airr:
+                miairr: false
+        junction_aa_length:
+            type: integer
+            description: Number of amino acids in junction_aa.
+            x-airr:
+                miairr: false
+        germline_alignment:
+            type: string
+            description: >
+                Assembled, aligned, full-length inferred ancestor of the clone spanning the same region
+                as the sequence_alignment field of nodes (typically the V(D)J region) and including the
+                same set of corrections and spacers (if any).
+            x-airr:
+                miairr: false
+                required: true
+        germline_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of germline_alignment.
+            x-airr:
+                miairr: false
+        v_alignment_start:
+            type: integer
+            description: >
+                Start position in the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        v_alignment_end:
+            type: integer
+            description: >
+                End position in the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        d_alignment_start:
+            type: integer
+            description: >
+                Start position of the D gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        d_alignment_end:
+            type: integer
+            description: >
+                End position of the D gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        j_alignment_start:
+            type: integer
+            description: >
+                Start position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        j_alignment_end:
+            type: integer
+            description: >
+                End position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        junction_start:
+            type: integer
+            description: Junction region start position in the alignment (1-based closed interval).
+            x-airr:
+                miairr: false
+        junction_end:
+            type: integer
+            description: Junction region end position in the alignment (1-based closed interval).
+            x-airr:
+                miairr: false
+        rearrangement_count:
+            type: integer
+            description: Number of rearrangements included in this clone
+            x-airr:
+                miairr: false
+        seed_id:
+            type: string
+            Description: rearrangment id for seed, null if no seed
+            x-airr:
+                miairr: false
+
+# 1-to-n relationship for a clone to its trees.
+Tree:
+    discriminator: AIRR
+    type: object
+    required:
+        - tree_id
+        - clone_id
+        - newick
+    properties:
+        tree_id:
+            type: string
+            description: Identifier for the tree.
+            x-airr:
+                miairr: false
+                required: true
+        clone_id:
+            type: string
+            description: Identifier for the clone.
+            x-airr:
+                miairr: false
+                required: true
+        newick:
+            type: string
+            description: Newick string of the tree edges.
+            x-airr:
+                miairr: false
+                required: true
+        nodes:
+            type: object
+            description: Dictionary of nodes in the tree, keyed by sequence_id string
+            x-airr:
+                miairr: false
+            additionalProperties:
+                $ref: '#/Node'
+
+# 1-to-n relationship between a tree and its nodes
+Node:
+    discriminator: AIRR
+    type: object
+    required:
+        - sequence_id
+    properties:
+        sequence_id:
+            type: string
+            description: >
+                Identifier for this node that matches the id in the newick string and, where possible,
+                the sequence_id in the source repertoire.
+            x-airr:
+                miairr: false
+                required: true
+        rearrangement_id:
+            type: string
+            description: >
+                Identifier for the Rearrangement object. May be identical to sequence_id,
+                but will usually be a univerally unique record locator for database applications.
+            x-airr:
+                miairr: false
+                required: false
+        sequence_alignment:
+            type: string
+            description: >
+                Nucleotide sequence of the node, aligned to the germline_alignment for this clone, including
+                including any indel corrections or spacers.
+            x-airr:
+                miairr: false
+        junction:
+            type: string
+            description: >
+                Junction region nucleotide sequence for the node, where the junction is defined as
+                the CDR3 plus the two flanking conserved codons.
+            x-airr:
+                miairr: false
+        junction_aa:
+            type: string
+            description: >
+                Amino acid translation of the junction.
+            x-airr:
+                miairr: false

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1443,19 +1443,31 @@ Rearrangement:
                 adc-api-optional: true
         locus:
             type: string
-            description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
+            enum:
+                - IGH
+                - IGI
+                - IGK
+                - IGL
+                - TRA
+                - TRB
+                - TRD
+                - TRG
+            description: >
+                Gene locus (chain type). Note that this field uses a controlled vocubulary that is meant to provide a
+                generic classification of the locus, not necessarily the correct designation according to a specific
+                nomenclature.
             example: IGH
             x-airr:
                 miairr: false
                 required: true
                 nullable: true
                 adc-api-optional: false
-                name: Locus
+                name: Gene locus
         v_call:
             type: string
             description: >
-                V gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHV4-59*01).
+                V gene with allele. If referring to a known reference sequence in a database
+                the relevant gene/allele nomenclature should be followed (e.g., IGHV4-59*01 if using IMGT/GENE-DB).
             example: IGHV4-59*01
             x-airr:
                 miairr: true
@@ -1464,48 +1476,11 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: V gene with allele
-        v_subgroup:
-            type: string
-            description: >
-                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4).
-            example: IGHV4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V gene subgroup
-        v_gene:
-            type: string
-            description: >
-                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
-            example: IGHV4-59
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V gene
-        v_allele:
-            type: string
-            description: >
-                V allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHV4-59*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V allele
         d_call:
             type: string
             description: >
-                First or only D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+                First or only D gene with allele. If referring to a known reference sequence in a database
+                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01 if using IMGT/GENE-DB).
             example: IGHD3-10*01
             x-airr:
                 miairr: true
@@ -1514,85 +1489,20 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: D gene with allele
-        d_subgroup:
-            type: string
-            description: >
-                D subgroup of the first or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3).
-            example: IGHD3
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D gene subgroup
-        d_gene:
-            type: string
-            description: >
-                First or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
-            example: IGHD3-10
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D gene
-        d_allele:
-            type: string
-            description: >
-                First or only D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D allele
         d2_call:
             type: string
             description: >
-                Second D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+                Second D gene with allele. If referring to a known reference sequence in a database the relevant
+                gene/allele nomenclature should be followed (e.g., IGHD3-10*01 if using IMGT/GENE-DB).
             example: IGHD3-10*01
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_subgroup:
-            type: string
-            description: >
-                D subgroup of the second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3).
-            example: IGHD3
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_gene:
-            type: string
-            description: >
-                Second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
-            example: IGHD3-10
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_allele:
-            type: string
-            description: >
-                Second D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_call:
             type: string
             description: >
-                J gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHJ4*02).
+                J gene with allele. If referring to a known reference sequence in a database the relevant
+                gene/allele nomenclature should be followed (e.g., IGHJ4*02 if using IMGT/GENE-DB).
             example: IGHJ4*02
             x-airr:
                 miairr: true
@@ -1601,48 +1511,11 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: J gene with allele
-        j_subgroup:
-            type: string
-            description: >
-                J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHJ4).
-            example: IGHJ4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J gene subgroup
-        j_gene:
-            type: string
-            description: >
-                J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHJ4).
-            example: IGHJ4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J gene
-        j_allele:
-            type: string
-            description: >
-                J allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHJ4*02 an allele
-                string of 02 should be used (not 1).
-            example: 02
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J allele
         c_call:
             type: string
             description: >
-                Constant region gene with allele. If referring to a known reference sequence in a database, such as
-                IMGT/GENE-DB, the relevant gene/allele nomenclature should be followed (e.g., IGHG1*01).
+                Constant region gene with allele. If referring to a known reference sequence in a database the
+                relevant gene/allele nomenclature should be followed (e.g., IGHG1*01 if using IMGT/GENE-DB).
             example: IGHG1*01
             x-airr:
                 miairr: true
@@ -1651,49 +1524,6 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: C region
-        c_subgroup:
-            type: string
-            description: >
-                Subgroup of the constant region gene. For immunoglobulins, this should be informative of the isotype
-                (e.g,, IgG). If referring to a known reference sequence in a database, such as IMGT/GENE-DB, the
-                relevant gene nomenclature should be followed (e.g., IGHG).
-            example: IGHG
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C gene subgroup
-        c_gene:
-            type: string
-            description: >
-                Constant region gene. For immunoglobulins, this should be informative about the subclass, if it exists
-                for the given isotype (e.g., IgG1 for IgG). In cases in which it is contested whether a sequence
-                constitutes a gene or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be
-                encoded as gene, not as allele (i.e., here, not in c_allele). If referring to a known reference sequence
-                in a database, such as IMGT/GENE-DB, the relevant gene nomenclature should be followed (e.g., IGHG1).
-            example: IGHG1
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C gene
-        c_allele:
-            type: string
-            description: >
-                Allele of constant region gene. In cases in which it is contested whether a sequence constitutes a gene
-                or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be encoded as gene, not as
-                allele (i.e., not here, but in c_gene). If referring to a known reference sequence in a database, such
-                as IMGT/GENE-DB, the relevant gene nomenclature should be followed. For example, for IGHG1*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C allele
         sequence_alignment:
             type: string
             description: >

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -343,7 +343,7 @@ Subject:
                 name: Age maximum
         age_unit:
             $ref: '#/Ontology'
-            description: unit of age range
+            description: Unit of age range
             example:
                 id: UO_0000036
                 value: year

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1504,7 +1504,7 @@ Rearrangement:
         d_call:
             type: string
             description: >
-                D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
             example: IGHD3-10*01
             x-airr:
@@ -1517,7 +1517,7 @@ Rearrangement:
         d_subgroup:
             type: string
             description: >
-                D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                D subgroup of the first or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed (e.g., IGHD3).
             example: IGHD3
             x-airr:
@@ -1529,7 +1529,7 @@ Rearrangement:
         d_gene:
             type: string
             description: >
-                D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed (e.g., IGHD3-10).
             example: IGHD3-10
             x-airr:
@@ -1541,7 +1541,7 @@ Rearrangement:
         d_allele:
             type: string
             description: >
-                D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
                 string of 01 should be used (not 1).
             example: 01
@@ -1551,6 +1551,43 @@ Rearrangement:
                 nullable: true
                 adc-api-optional: false
                 name: D allele
+        d2_call:
+            type: string
+            description: >
+                Second D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+            example: IGHD3-10*01
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_subgroup:
+            type: string
+            description: >
+                D subgroup of the second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_gene:
+            type: string
+            description: >
+                Second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_allele:
+            type: string
+            description: >
+                Second D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_call:
             type: string
             description: >
@@ -1713,7 +1750,8 @@ Rearrangement:
         np1:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the V and D segments or V and J segments.
+                Nucleotide sequence of the combined N/P region between the V segment and first D segment
+                or between the V and J segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1727,7 +1765,8 @@ Rearrangement:
         np2:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the D and J segments.
+                Nucleotide sequence of the combined N/P region between either the first D and J segments
+                or the first D and second D segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1735,6 +1774,20 @@ Rearrangement:
             type: string
             description: >
                 Amino acid translation of the np2 field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3:
+            type: string
+            description: >
+                Nucleotide sequence of the combined N/P region between the second D segment and J segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3_aa:
+            type: string
+            description: >
+                Amino acid translation of the np3 field.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1864,13 +1917,13 @@ Rearrangement:
                 adc-api-optional: true
         d_score:
             type: number
-            description: Alignment score for the D gene alignment.
+            description: Alignment score for the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_identity:
             type: number
-            description: Fractional identity for the D gene alignment.
+            description: Fractional identity for the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1878,13 +1931,39 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the D gene assignment as defined by the alignment tool.
+                support for the first or only D segment as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_cigar:
             type: string
-            description: CIGAR string for the D gene alignment.
+            description: CIGAR string for the first or only D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_score:
+            type: number
+            description: Alignment score for the second D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_identity:
+            type: number
+            description: Fractional identity for the second D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_support:
+            type: number
+            description: >
+                D gene alignment E-value, p-value, likelihood, probability or other similar measure of
+                support for the second D segment as defined by the alignment tool.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_cigar:
+            type: string
+            description: CIGAR string for the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1987,43 +2066,89 @@ Rearrangement:
         d_sequence_start:
             type: integer
             description: >
-                Start position of the D segment in the query sequence (1-based closed interval).
+                Start position of the first or only D segment in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_end:
             type: integer
             description: >
-                End position of the D segment in the query sequence (1-based closed interval).
+                End position of the first or only D segment in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_germline_start:
             type: integer
             description: >
-                Alignment start position in the D gene reference sequence (1-based closed interval).
+                Alignment start position in the D gene reference sequence for the first or only
+                D segment (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_germline_end:
             type: integer
             description: >
-                Alignment end position in the D gene reference sequence (1-based closed interval).
+                Alignment end position in the D gene reference sequence for the first or only
+                D segment (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_start:
             type: integer
             description: >
-                Start position of the D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the first or only D segment in both the sequence_alignment
+                and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_end:
             type: integer
             description: >
-                End position of the D segment in both the sequence_alignment and germline_alignment fields
+                End position of the first or only D segment in both the sequence_alignment
+                and germline_alignment fields (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_start:
+            type: integer
+            description: >
+                Start position of the second D segment in the query sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_end:
+            type: integer
+            description: >
+                End position of the second D segment in the query sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_start:
+            type: integer
+            description: >
+                Alignment start position in the second D gene reference sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_end:
+            type: integer
+            description: >
+                Alignment end position in the second D gene reference sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_alignment_start:
+            type: integer
+            description: >
+                Start position of the second D segment in both the sequence_alignment and germline_alignment fields
+                (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_alignment_end:
+            type: integer
+            description: >
+                End position of the second D segment in both the sequence_alignment and germline_alignment fields
                 (1-based closed interval).
             x-airr:
                 miairr: false
@@ -2294,25 +2419,42 @@ Rearrangement:
                 adc-api-optional: false
         np1_length:
             type: integer
-            description: Number of nucleotides between the V and D segments or V and J segments.
+            description: >
+                Number of nucleotides between the V and first D segment or between
+                the V and J segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np2_length:
             type: integer
-            description: Number of nucleotides between the D and J segments.
+            description: >
+                Number of nucleotides between either the first D and J segments
+                or the first D and second D segments.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3_length:
+            type: integer
+            description: >
+                Number of nucleotides between the second D segment and J segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n1_length:
             type: integer
-            description: Number of untemplated nucleotides 5' of the D segment.
+            description: Number of untemplated nucleotides 5' of the first or only D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n2_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the D segment.
+            description: Number of untemplated nucleotides 3' of the first or only D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        n3_length:
+            type: integer
+            description: Number of untemplated nucleotides 3' of the second D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2324,13 +2466,25 @@ Rearrangement:
                 adc-api-optional: true
         p5d_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the D segment.
+            description: Number of palindromic nucleotides 5' of the first or only D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the D segment.
+            description: Number of palindromic nucleotides 3' of the first or only D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        p5d2_length:
+            type: integer
+            description: Number of palindromic nucleotides 5' of the second D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        p3d2_length:
+            type: integer
+            description: Number of palindromic nucleotides 3' of the second D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2446,4 +2600,3 @@ Rearrangement:
             example: ENSEMBL, Homo sapiens build 90, 2017-10-01
             x-airr:
                 deprecated: true
-

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1360,7 +1360,7 @@ Alignment:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
         data_processing_id:
             type: string
             description: >
@@ -1453,7 +1453,7 @@ Rearrangement:
                 - TRD
                 - TRG
             description: >
-                Gene locus (chain type). Note that this field uses a controlled vocubulary that is meant to provide a
+                Gene locus (chain type). Note that this field uses a controlled vocabulary that is meant to provide a
                 generic classification of the locus, not necessarily the correct designation according to a specific
                 nomenclature.
             example: IGH
@@ -2393,7 +2393,7 @@ Rearrangement:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
             x-airr:
                 miairr: false
                 required: true

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1641,9 +1641,9 @@ Rearrangement:
         c_call:
             type: string
             description: >
-                C region gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHM*01).
-            example: IGHM*01
+                Constant region gene with allele. If referring to a known reference sequence in a database, such as
+                IMGT/GENE-DB, the relevant gene/allele nomenclature should be followed (e.g., IGHG1*01).
+            example: IGHG1*01
             x-airr:
                 miairr: true
                 required: true
@@ -1654,9 +1654,10 @@ Rearrangement:
         c_subgroup:
             type: string
             description: >
-                C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHM).
-            example: IGHM
+                Subgroup of the constant region gene. For immunoglobulins, this should be informative of the isotype
+                (e.g,, IgG). If referring to a known reference sequence in a database, such as IMGT/GENE-DB, the
+                relevant gene nomenclature should be followed (e.g., IGHG).
+            example: IGHG
             x-airr:
                 miairr: false
                 required: true
@@ -1666,9 +1667,12 @@ Rearrangement:
         c_gene:
             type: string
             description: >
-                C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHM).
-            example: IGHM
+                Constant region gene. For immunoglobulins, this should be informative about the subclass, if it exists
+                for the given isotype (e.g., IgG1 for IgG). In cases in which it is contested whether a sequence
+                constitutes a gene or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be
+                encoded as gene, not as allele (i.e., here, not in c_allele). If referring to a known reference sequence
+                in a database, such as IMGT/GENE-DB, the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
             x-airr:
                 miairr: false
                 required: true
@@ -1678,8 +1682,10 @@ Rearrangement:
         c_allele:
             type: string
             description: >
-                C allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHM*01 an allele
+                Allele of constant region gene. In cases in which it is contested whether a sequence constitutes a gene
+                or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be encoded as gene, not as
+                allele (i.e., not here, but in c_gene). If referring to a known reference sequence in a database, such
+                as IMGT/GENE-DB, the relevant gene nomenclature should be followed. For example, for IGHG1*01 an allele
                 string of 01 should be used (not 1).
             example: 01
             x-airr:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -927,7 +927,12 @@ NucleicAcidProcessing:
                 name: Protocol IDs
         pcr_target:
             type: array
-            description: Target locus information
+            description: >
+                If a PCR step was performed that specifically targets the IG/TR loci, the target and primer locations
+                need to be provided here. This field holds an array of PCRTarget objects, so that multiplex PCR setups
+                amplifying multiple loci at the same time can be annotated using one record per locus. PCR setups not
+                targeting any specific locus must not annotate this field but select the appropriate 
+                library_generation_method instead.
             items:
                 $ref: '#/PCRTarget'
         complete_sequences:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1444,6 +1444,13 @@ Rearrangement:
         locus:
             type: string
             description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
+            example: IGH
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: Locus
         v_call:
             type: string
             description: >
@@ -1456,7 +1463,44 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
+                name: V gene with allele
+        v_subgroup:
+            type: string
+            description: >
+                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4).
+            example: IGHV4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: V gene subgroup
+        v_gene:
+            type: string
+            description: >
+                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+            example: IGHV4-59
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
                 name: V gene
+        v_allele:
+            type: string
+            description: >
+                V allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHV4-59*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: V allele
         d_call:
             type: string
             description: >
@@ -1469,7 +1513,44 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
+                name: D gene with allele
+        d_subgroup:
+            type: string
+            description: >
+                D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: D gene subgroup
+        d_gene:
+            type: string
+            description: >
+                D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
                 name: D gene
+        d_allele:
+            type: string
+            description: >
+                D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: D allele
         j_call:
             type: string
             description: >
@@ -1482,7 +1563,44 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
+                name: J gene with allele
+        j_subgroup:
+            type: string
+            description: >
+                J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: J gene subgroup
+        j_gene:
+            type: string
+            description: >
+                J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
                 name: J gene
+        j_allele:
+            type: string
+            description: >
+                J allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHJ4*02 an allele
+                string of 02 should be used (not 1).
+            example: 02
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: J allele
         c_call:
             type: string
             description: >
@@ -1496,6 +1614,43 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: C region
+        c_subgroup:
+            type: string
+            description: >
+                C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHM).
+            example: IGHM
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C gene subgroup
+        c_gene:
+            type: string
+            description: >
+                C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHM).
+            example: IGHM
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C gene
+        c_allele:
+            type: string
+            description: >
+                C allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHM*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C allele
         sequence_alignment:
             type: string
             description: >

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -946,8 +946,8 @@ NucleicAcidProcessing:
                 - "complete+untemplated"
             description: >
                 To be considered `complete`, the procedure used for library construction MUST generate sequences that
-                1) include the first V segment codon that encodes the mature polypeptide chain (i.e. after the
-                leader sequence) and 2) include the last complete codon of the J segment (i.e. 1 bp 5' of the J->C
+                1) include the first V gene codon that encodes the mature polypeptide chain (i.e. after the
+                leader sequence) and 2) include the last complete codon of the J gene (i.e. 1 bp 5' of the J->C
                 splice site) and 3) provide sequence information for all positions between 1) and 2). To be considered
                 `complete & untemplated`, the sections of the sequences defined in points 1) to 3) of the previous
                 sentence MUST be untemplated, i.e. MUST NOT overlap with the primers used in library preparation.
@@ -1434,7 +1434,7 @@ Rearrangement:
                 True if the V(D)J sequence is predicted to be productive.
         vj_in_frame:
             type: boolean
-            description: True if the V and J segment alignments are in-frame.
+            description: True if the V and J gene alignments are in-frame.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1589,8 +1589,8 @@ Rearrangement:
         np1:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the V segment and first D segment
-                or between the V and J segments.
+                Nucleotide sequence of the combined N/P region between the V gene and
+                first D gene alignment or between the V gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1604,8 +1604,8 @@ Rearrangement:
         np2:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between either the first D and J segments
-                or the first D and second D segments.
+                Nucleotide sequence of the combined N/P region between either the first D gene and J gene
+                alignments or the first D gene and second D gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1619,7 +1619,8 @@ Rearrangement:
         np3:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the second D segment and J segment.
+                Nucleotide sequence of the combined N/P region between the second D gene
+                and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1770,7 +1771,7 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the first or only D segment as defined by the alignment tool.
+                support for the first or only D gene as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1796,7 +1797,7 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the second D segment as defined by the alignment tool.
+                support for the second D gene as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1861,14 +1862,14 @@ Rearrangement:
         v_sequence_start:
             type: integer
             description: >
-                Start position of the V segment in the query sequence (1-based closed interval).
+                Start position of the V gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         v_sequence_end:
             type: integer
             description: >
-                End position of the V segment in the query sequence (1-based closed interval).
+                End position of the V gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1889,30 +1890,32 @@ Rearrangement:
         v_alignment_start:
             type: integer
             description: >
-                Start position in the V segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         v_alignment_end:
             type: integer
             description: >
-                End position in the V segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_start:
             type: integer
             description: >
-                Start position of the first or only D segment in the query sequence (1-based closed interval).
+                Start position of the first or only D gene in the query sequence.
+                (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_end:
             type: integer
             description: >
-                End position of the first or only D segment in the query sequence (1-based closed interval).
+                End position of the first or only D gene in the query sequence.
+                (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1920,7 +1923,7 @@ Rearrangement:
             type: integer
             description: >
                 Alignment start position in the D gene reference sequence for the first or only
-                D segment (1-based closed interval).
+                D gene (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1928,14 +1931,14 @@ Rearrangement:
             type: integer
             description: >
                 Alignment end position in the D gene reference sequence for the first or only
-                D segment (1-based closed interval).
+                D gene (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_start:
             type: integer
             description: >
-                Start position of the first or only D segment in both the sequence_alignment
+                Start position of the first or only D gene in both the sequence_alignment
                 and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
@@ -1943,7 +1946,7 @@ Rearrangement:
         d_alignment_end:
             type: integer
             description: >
-                End position of the first or only D segment in both the sequence_alignment
+                End position of the first or only D gene in both the sequence_alignment
                 and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
@@ -1951,14 +1954,14 @@ Rearrangement:
         d2_sequence_start:
             type: integer
             description: >
-                Start position of the second D segment in the query sequence (1-based closed interval).
+                Start position of the second D gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d2_sequence_end:
             type: integer
             description: >
-                End position of the second D segment in the query sequence (1-based closed interval).
+                End position of the second D gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1979,30 +1982,30 @@ Rearrangement:
         d2_alignment_start:
             type: integer
             description: >
-                Start position of the second D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the second D gene alignment in both the sequence_alignment and
+                germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d2_alignment_end:
             type: integer
             description: >
-                End position of the second D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the second D gene alignment in both the sequence_alignment and
+                germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_sequence_start:
             type: integer
             description: >
-                Start position of the J segment in the query sequence (1-based closed interval).
+                Start position of the J gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_sequence_end:
             type: integer
             description: >
-                End position of the J segment in the query sequence (1-based closed interval).
+                End position of the J gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2023,16 +2026,16 @@ Rearrangement:
         j_alignment_start:
             type: integer
             description: >
-                Start position of the J segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_alignment_end:
             type: integer
             description: >
-                End position of the J segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2123,7 +2126,7 @@ Rearrangement:
         v_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the V segment, including any
+                Aligned portion of query sequence assigned to the V gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2138,7 +2141,7 @@ Rearrangement:
         d_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the D segment, including any
+                Aligned portion of query sequence assigned to the first or only D gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2150,10 +2153,25 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        d2_sequence_alignment:
+            type: string
+            description: >
+                Aligned portion of query sequence assigned to the second D gene, including any
+                indel corrections or numbering spacers.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of the d2_sequence_alignment field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the J segment, including any
+                Aligned portion of query sequence assigned to the J gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2212,6 +2230,22 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        d2_germline_alignment:
+            type: string
+            description: >
+                Aligned D gene germline sequence spanning the same region
+                as the d2_sequence_alignment field and including the same set
+                of corrections and spacers (if any).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of the d2_germline_alignment field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_germline_alignment:
             type: string
             description: >
@@ -2259,77 +2293,77 @@ Rearrangement:
         np1_length:
             type: integer
             description: >
-                Number of nucleotides between the V and first D segment or between
-                the V and J segments.
+                Number of nucleotides between the V gene and first D gene alignments or
+                between the V gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np2_length:
             type: integer
             description: >
-                Number of nucleotides between either the first D and J segments
-                or the first D and second D segments.
+                Number of nucleotides between either the first D gene and J gene alignments
+                or the first D gene and second D gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np3_length:
             type: integer
             description: >
-                Number of nucleotides between the second D segment and J segment.
+                Number of nucleotides between the second D gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n1_length:
             type: integer
-            description: Number of untemplated nucleotides 5' of the first or only D segment.
+            description: Number of untemplated nucleotides 5' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n2_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the first or only D segment.
+            description: Number of untemplated nucleotides 3' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n3_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the second D segment.
+            description: Number of untemplated nucleotides 3' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3v_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the V segment.
+            description: Number of palindromic nucleotides 3' of the V gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5d_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the first or only D segment.
+            description: Number of palindromic nucleotides 5' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the first or only D segment.
+            description: Number of palindromic nucleotides 3' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5d2_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the second D segment.
+            description: Number of palindromic nucleotides 5' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d2_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the second D segment.
+            description: Number of palindromic nucleotides 3' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5j_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the J segment.
+            description: Number of palindromic nucleotides 5' of the J gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2439,3 +2473,244 @@ Rearrangement:
             example: ENSEMBL, Homo sapiens build 90, 2017-10-01
             x-airr:
                 deprecated: true
+
+# A unique inferred clone object that has been constructed within a single data processing
+# for a single repertoire and a subset of its sequences and/or rearrangements.
+Clone:
+    discriminator: AIRR
+    type: object
+    required:
+        - clone_id
+        - repertoire_id
+        - germline_alignment
+    properties:
+        clone_id:
+            type: string
+            description: Identifier for the clone.
+            x-airr:
+                miairr: false
+                required: true
+        repertoire_id:
+            type: string
+            description: Identifier to the associated repertoire in study metadata.
+            x-airr:
+                miairr: false
+                required: true
+        data_processing_id:
+            type: string
+            description: Identifier of the data processing object in the repertoire metadata for this clone.
+            x-airr:
+                miairr: false
+                required: false
+        sequences:
+            type: array
+            items:
+                type: string
+            description: List of sequence_ids that are members of the clone.
+            x-airr:
+                miairr: false
+        rearrangements:
+            type: array
+            items:
+                type: string
+            description: List of rearrangement_ids that are members of the clone.
+            x-airr:
+                miairr: false
+        v_call:
+            type: string
+            description: >
+                V gene with allele of the inferred ancestral of the clone. For example, IGHV4-59*01.
+            example: IGHV4-59*01
+            x-airr:
+                miairr: false
+        d_call:
+            type: string
+            description: >
+                D gene with allele of the inferred ancestor of the clone. For example, IGHD3-10*01.
+            example: IGHD3-10*01
+            x-airr:
+                miairr: false
+        j_call:
+            type: string
+            description: >
+                J gene with allele of the inferred ancestor of the clone. For example, IGHJ4*02.
+            example: IGHJ4*02
+            x-airr:
+                miairr: false
+        junction:
+            type: string
+            description: >
+                Nucleotide sequence for the junction region of the inferred ancestor of the clone,
+                where the junction is defined as the CDR3 plus the two flanking conserved codons.
+        junction_aa:
+            type: string
+            description: >
+                Amino acid translation of the junction.
+            x-airr:
+                miairr: false
+        junction_length:
+            type: integer
+            description: Number of nucleotides in the junction.
+            x-airr:
+                miairr: false
+        junction_aa_length:
+            type: integer
+            description: Number of amino acids in junction_aa.
+            x-airr:
+                miairr: false
+        germline_alignment:
+            type: string
+            description: >
+                Assembled, aligned, full-length inferred ancestor of the clone spanning the same region
+                as the sequence_alignment field of nodes (typically the V(D)J region) and including the
+                same set of corrections and spacers (if any).
+            x-airr:
+                miairr: false
+                required: true
+        germline_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of germline_alignment.
+            x-airr:
+                miairr: false
+        v_alignment_start:
+            type: integer
+            description: >
+                Start position in the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        v_alignment_end:
+            type: integer
+            description: >
+                End position in the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        d_alignment_start:
+            type: integer
+            description: >
+                Start position of the D gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        d_alignment_end:
+            type: integer
+            description: >
+                End position of the D gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        j_alignment_start:
+            type: integer
+            description: >
+                Start position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        j_alignment_end:
+            type: integer
+            description: >
+                End position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        junction_start:
+            type: integer
+            description: Junction region start position in the alignment (1-based closed interval).
+            x-airr:
+                miairr: false
+        junction_end:
+            type: integer
+            description: Junction region end position in the alignment (1-based closed interval).
+            x-airr:
+                miairr: false
+        rearrangement_count:
+            type: integer
+            description: Number of rearrangements included in this clone
+            x-airr:
+                miairr: false
+        seed_id:
+            type: string
+            Description: rearrangment id for seed, null if no seed
+            x-airr:
+                miairr: false
+
+# 1-to-n relationship for a clone to its trees.
+Tree:
+    discriminator: AIRR
+    type: object
+    required:
+        - tree_id
+        - clone_id
+        - newick
+    properties:
+        tree_id:
+            type: string
+            description: Identifier for the tree.
+            x-airr:
+                miairr: false
+                required: true
+        clone_id:
+            type: string
+            description: Identifier for the clone.
+            x-airr:
+                miairr: false
+                required: true
+        newick:
+            type: string
+            description: Newick string of the tree edges.
+            x-airr:
+                miairr: false
+                required: true
+        nodes:
+            type: object
+            description: Dictionary of nodes in the tree, keyed by sequence_id string
+            x-airr:
+                miairr: false
+            additionalProperties:
+                $ref: '#/Node'
+
+# 1-to-n relationship between a tree and its nodes
+Node:
+    discriminator: AIRR
+    type: object
+    required:
+        - sequence_id
+    properties:
+        sequence_id:
+            type: string
+            description: >
+                Identifier for this node that matches the id in the newick string and, where possible,
+                the sequence_id in the source repertoire.
+            x-airr:
+                miairr: false
+                required: true
+        rearrangement_id:
+            type: string
+            description: >
+                Identifier for the Rearrangement object. May be identical to sequence_id,
+                but will usually be a univerally unique record locator for database applications.
+            x-airr:
+                miairr: false
+                required: false
+        sequence_alignment:
+            type: string
+            description: >
+                Nucleotide sequence of the node, aligned to the germline_alignment for this clone, including
+                including any indel corrections or spacers.
+            x-airr:
+                miairr: false
+        junction:
+            type: string
+            description: >
+                Junction region nucleotide sequence for the node, where the junction is defined as
+                the CDR3 plus the two flanking conserved codons.
+            x-airr:
+                miairr: false
+        junction_aa:
+            type: string
+            description: >
+                Amino acid translation of the junction.
+            x-airr:
+                miairr: false

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1443,19 +1443,31 @@ Rearrangement:
                 adc-api-optional: true
         locus:
             type: string
-            description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
+            enum:
+                - IGH
+                - IGI
+                - IGK
+                - IGL
+                - TRA
+                - TRB
+                - TRD
+                - TRG
+            description: >
+                Gene locus (chain type). Note that this field uses a controlled vocubulary that is meant to provide a
+                generic classification of the locus, not necessarily the correct designation according to a specific
+                nomenclature.
             example: IGH
             x-airr:
                 miairr: false
                 required: true
                 nullable: true
                 adc-api-optional: false
-                name: Locus
+                name: Gene locus
         v_call:
             type: string
             description: >
-                V gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHV4-59*01).
+                V gene with allele. If referring to a known reference sequence in a database
+                the relevant gene/allele nomenclature should be followed (e.g., IGHV4-59*01 if using IMGT/GENE-DB).
             example: IGHV4-59*01
             x-airr:
                 miairr: true
@@ -1464,48 +1476,11 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: V gene with allele
-        v_subgroup:
-            type: string
-            description: >
-                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4).
-            example: IGHV4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V gene subgroup
-        v_gene:
-            type: string
-            description: >
-                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
-            example: IGHV4-59
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V gene
-        v_allele:
-            type: string
-            description: >
-                V allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHV4-59*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V allele
         d_call:
             type: string
             description: >
-                First or only D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+                First or only D gene with allele. If referring to a known reference sequence in a database
+                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01 if using IMGT/GENE-DB).
             example: IGHD3-10*01
             x-airr:
                 miairr: true
@@ -1514,85 +1489,20 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: D gene with allele
-        d_subgroup:
-            type: string
-            description: >
-                D subgroup of the first or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3).
-            example: IGHD3
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D gene subgroup
-        d_gene:
-            type: string
-            description: >
-                First or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
-            example: IGHD3-10
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D gene
-        d_allele:
-            type: string
-            description: >
-                First or only D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D allele
         d2_call:
             type: string
             description: >
-                Second D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+                Second D gene with allele. If referring to a known reference sequence in a database the relevant
+                gene/allele nomenclature should be followed (e.g., IGHD3-10*01 if using IMGT/GENE-DB).
             example: IGHD3-10*01
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_subgroup:
-            type: string
-            description: >
-                D subgroup of the second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3).
-            example: IGHD3
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_gene:
-            type: string
-            description: >
-                Second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
-            example: IGHD3-10
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_allele:
-            type: string
-            description: >
-                Second D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_call:
             type: string
             description: >
-                J gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHJ4*02).
+                J gene with allele. If referring to a known reference sequence in a database the relevant
+                gene/allele nomenclature should be followed (e.g., IGHJ4*02 if using IMGT/GENE-DB).
             example: IGHJ4*02
             x-airr:
                 miairr: true
@@ -1601,48 +1511,11 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: J gene with allele
-        j_subgroup:
-            type: string
-            description: >
-                J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHJ4).
-            example: IGHJ4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J gene subgroup
-        j_gene:
-            type: string
-            description: >
-                J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHJ4).
-            example: IGHJ4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J gene
-        j_allele:
-            type: string
-            description: >
-                J allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHJ4*02 an allele
-                string of 02 should be used (not 1).
-            example: 02
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J allele
         c_call:
             type: string
             description: >
-                Constant region gene with allele. If referring to a known reference sequence in a database, such as
-                IMGT/GENE-DB, the relevant gene/allele nomenclature should be followed (e.g., IGHG1*01).
+                Constant region gene with allele. If referring to a known reference sequence in a database the
+                relevant gene/allele nomenclature should be followed (e.g., IGHG1*01 if using IMGT/GENE-DB).
             example: IGHG1*01
             x-airr:
                 miairr: true
@@ -1651,49 +1524,6 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: C region
-        c_subgroup:
-            type: string
-            description: >
-                Subgroup of the constant region gene. For immunoglobulins, this should be informative of the isotype
-                (e.g,, IgG). If referring to a known reference sequence in a database, such as IMGT/GENE-DB, the
-                relevant gene nomenclature should be followed (e.g., IGHG).
-            example: IGHG
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C gene subgroup
-        c_gene:
-            type: string
-            description: >
-                Constant region gene. For immunoglobulins, this should be informative about the subclass, if it exists
-                for the given isotype (e.g., IgG1 for IgG). In cases in which it is contested whether a sequence
-                constitutes a gene or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be
-                encoded as gene, not as allele (i.e., here, not in c_allele). If referring to a known reference sequence
-                in a database, such as IMGT/GENE-DB, the relevant gene nomenclature should be followed (e.g., IGHG1).
-            example: IGHG1
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C gene
-        c_allele:
-            type: string
-            description: >
-                Allele of constant region gene. In cases in which it is contested whether a sequence constitutes a gene
-                or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be encoded as gene, not as
-                allele (i.e., not here, but in c_gene). If referring to a known reference sequence in a database, such
-                as IMGT/GENE-DB, the relevant gene nomenclature should be followed. For example, for IGHG1*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C allele
         sequence_alignment:
             type: string
             description: >

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -343,7 +343,7 @@ Subject:
                 name: Age maximum
         age_unit:
             $ref: '#/Ontology'
-            description: unit of age range
+            description: Unit of age range
             example:
                 id: UO_0000036
                 value: year

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1504,7 +1504,7 @@ Rearrangement:
         d_call:
             type: string
             description: >
-                D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
             example: IGHD3-10*01
             x-airr:
@@ -1517,7 +1517,7 @@ Rearrangement:
         d_subgroup:
             type: string
             description: >
-                D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                D subgroup of the first or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed (e.g., IGHD3).
             example: IGHD3
             x-airr:
@@ -1529,7 +1529,7 @@ Rearrangement:
         d_gene:
             type: string
             description: >
-                D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed (e.g., IGHD3-10).
             example: IGHD3-10
             x-airr:
@@ -1541,7 +1541,7 @@ Rearrangement:
         d_allele:
             type: string
             description: >
-                D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
                 string of 01 should be used (not 1).
             example: 01
@@ -1551,6 +1551,43 @@ Rearrangement:
                 nullable: true
                 adc-api-optional: false
                 name: D allele
+        d2_call:
+            type: string
+            description: >
+                Second D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+            example: IGHD3-10*01
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_subgroup:
+            type: string
+            description: >
+                D subgroup of the second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_gene:
+            type: string
+            description: >
+                Second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_allele:
+            type: string
+            description: >
+                Second D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_call:
             type: string
             description: >
@@ -1713,7 +1750,8 @@ Rearrangement:
         np1:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the V and D segments or V and J segments.
+                Nucleotide sequence of the combined N/P region between the V segment and first D segment
+                or between the V and J segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1727,7 +1765,8 @@ Rearrangement:
         np2:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the D and J segments.
+                Nucleotide sequence of the combined N/P region between either the first D and J segments
+                or the first D and second D segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1735,6 +1774,20 @@ Rearrangement:
             type: string
             description: >
                 Amino acid translation of the np2 field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3:
+            type: string
+            description: >
+                Nucleotide sequence of the combined N/P region between the second D segment and J segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3_aa:
+            type: string
+            description: >
+                Amino acid translation of the np3 field.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1864,13 +1917,13 @@ Rearrangement:
                 adc-api-optional: true
         d_score:
             type: number
-            description: Alignment score for the D gene alignment.
+            description: Alignment score for the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_identity:
             type: number
-            description: Fractional identity for the D gene alignment.
+            description: Fractional identity for the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1878,13 +1931,39 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the D gene assignment as defined by the alignment tool.
+                support for the first or only D segment as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_cigar:
             type: string
-            description: CIGAR string for the D gene alignment.
+            description: CIGAR string for the first or only D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_score:
+            type: number
+            description: Alignment score for the second D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_identity:
+            type: number
+            description: Fractional identity for the second D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_support:
+            type: number
+            description: >
+                D gene alignment E-value, p-value, likelihood, probability or other similar measure of
+                support for the second D segment as defined by the alignment tool.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_cigar:
+            type: string
+            description: CIGAR string for the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1987,43 +2066,89 @@ Rearrangement:
         d_sequence_start:
             type: integer
             description: >
-                Start position of the D segment in the query sequence (1-based closed interval).
+                Start position of the first or only D segment in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_end:
             type: integer
             description: >
-                End position of the D segment in the query sequence (1-based closed interval).
+                End position of the first or only D segment in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_germline_start:
             type: integer
             description: >
-                Alignment start position in the D gene reference sequence (1-based closed interval).
+                Alignment start position in the D gene reference sequence for the first or only
+                D segment (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_germline_end:
             type: integer
             description: >
-                Alignment end position in the D gene reference sequence (1-based closed interval).
+                Alignment end position in the D gene reference sequence for the first or only
+                D segment (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_start:
             type: integer
             description: >
-                Start position of the D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the first or only D segment in both the sequence_alignment
+                and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_end:
             type: integer
             description: >
-                End position of the D segment in both the sequence_alignment and germline_alignment fields
+                End position of the first or only D segment in both the sequence_alignment
+                and germline_alignment fields (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_start:
+            type: integer
+            description: >
+                Start position of the second D segment in the query sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_end:
+            type: integer
+            description: >
+                End position of the second D segment in the query sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_start:
+            type: integer
+            description: >
+                Alignment start position in the second D gene reference sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_end:
+            type: integer
+            description: >
+                Alignment end position in the second D gene reference sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_alignment_start:
+            type: integer
+            description: >
+                Start position of the second D segment in both the sequence_alignment and germline_alignment fields
+                (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_alignment_end:
+            type: integer
+            description: >
+                End position of the second D segment in both the sequence_alignment and germline_alignment fields
                 (1-based closed interval).
             x-airr:
                 miairr: false
@@ -2294,25 +2419,42 @@ Rearrangement:
                 adc-api-optional: false
         np1_length:
             type: integer
-            description: Number of nucleotides between the V and D segments or V and J segments.
+            description: >
+                Number of nucleotides between the V and first D segment or between
+                the V and J segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np2_length:
             type: integer
-            description: Number of nucleotides between the D and J segments.
+            description: >
+                Number of nucleotides between either the first D and J segments
+                or the first D and second D segments.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3_length:
+            type: integer
+            description: >
+                Number of nucleotides between the second D segment and J segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n1_length:
             type: integer
-            description: Number of untemplated nucleotides 5' of the D segment.
+            description: Number of untemplated nucleotides 5' of the first or only D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n2_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the D segment.
+            description: Number of untemplated nucleotides 3' of the first or only D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        n3_length:
+            type: integer
+            description: Number of untemplated nucleotides 3' of the second D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2324,13 +2466,25 @@ Rearrangement:
                 adc-api-optional: true
         p5d_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the D segment.
+            description: Number of palindromic nucleotides 5' of the first or only D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the D segment.
+            description: Number of palindromic nucleotides 3' of the first or only D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        p5d2_length:
+            type: integer
+            description: Number of palindromic nucleotides 5' of the second D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        p3d2_length:
+            type: integer
+            description: Number of palindromic nucleotides 3' of the second D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2446,4 +2600,3 @@ Rearrangement:
             example: ENSEMBL, Homo sapiens build 90, 2017-10-01
             x-airr:
                 deprecated: true
-

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1454,8 +1454,8 @@ Rearrangement:
         v_call:
             type: string
             description: >
-                V gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHV4-59*01).
+                V gene with allele. If referring to a known reference sequence in a database
+                the relevant gene/allele nomenclature should be followed (e.g., IGHV4-59*01 if using IMGT/GENE-DB).
             example: IGHV4-59*01
             x-airr:
                 miairr: true
@@ -1464,48 +1464,11 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: V gene with allele
-        v_subgroup:
-            type: string
-            description: >
-                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4).
-            example: IGHV4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V gene subgroup
-        v_gene:
-            type: string
-            description: >
-                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
-            example: IGHV4-59
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V gene
-        v_allele:
-            type: string
-            description: >
-                V allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHV4-59*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: V allele
         d_call:
             type: string
             description: >
-                First or only D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+                First or only D gene with allele. If referring to a known reference sequence in a database
+                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01 if using IMGT/GENE-DB).
             example: IGHD3-10*01
             x-airr:
                 miairr: true
@@ -1514,85 +1477,20 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: D gene with allele
-        d_subgroup:
-            type: string
-            description: >
-                D subgroup of the first or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3).
-            example: IGHD3
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D gene subgroup
-        d_gene:
-            type: string
-            description: >
-                First or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
-            example: IGHD3-10
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D gene
-        d_allele:
-            type: string
-            description: >
-                First or only D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: D allele
         d2_call:
             type: string
             description: >
-                Second D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+                Second D gene with allele. If referring to a known reference sequence in a database the relevant
+                gene/allele nomenclature should be followed (e.g., IGHD3-10*01 if using IMGT/GENE-DB).
             example: IGHD3-10*01
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_subgroup:
-            type: string
-            description: >
-                D subgroup of the second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3).
-            example: IGHD3
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_gene:
-            type: string
-            description: >
-                Second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
-            example: IGHD3-10
-            x-airr:
-                miairr: false
-                adc-api-optional: true
-        d2_allele:
-            type: string
-            description: >
-                Second D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_call:
             type: string
             description: >
-                J gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHJ4*02).
+                J gene with allele. If referring to a known reference sequence in a database the relevant
+                gene/allele nomenclature should be followed (e.g., IGHJ4*02 if using IMGT/GENE-DB).
             example: IGHJ4*02
             x-airr:
                 miairr: true
@@ -1601,48 +1499,11 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: J gene with allele
-        j_subgroup:
-            type: string
-            description: >
-                J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHJ4).
-            example: IGHJ4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J gene subgroup
-        j_gene:
-            type: string
-            description: >
-                J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHJ4).
-            example: IGHJ4
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J gene
-        j_allele:
-            type: string
-            description: >
-                J allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHJ4*02 an allele
-                string of 02 should be used (not 1).
-            example: 02
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: J allele
         c_call:
             type: string
             description: >
-                Constant region gene with allele. If referring to a known reference sequence in a database, such as
-                IMGT/GENE-DB, the relevant gene/allele nomenclature should be followed (e.g., IGHG1*01).
+                Constant region gene with allele. If referring to a known reference sequence in a database the
+                relevant gene/allele nomenclature should be followed (e.g., IGHG1*01 if using IMGT/GENE-DB).
             example: IGHG1*01
             x-airr:
                 miairr: true
@@ -1651,49 +1512,6 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: C region
-        c_subgroup:
-            type: string
-            description: >
-                Subgroup of the constant region gene. For immunoglobulins, this should be informative of the isotype
-                (e.g,, IgG). If referring to a known reference sequence in a database, such as IMGT/GENE-DB, the
-                relevant gene nomenclature should be followed (e.g., IGHG).
-            example: IGHG
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C gene subgroup
-        c_gene:
-            type: string
-            description: >
-                Constant region gene. For immunoglobulins, this should be informative about the subclass, if it exists
-                for the given isotype (e.g., IgG1 for IgG). In cases in which it is contested whether a sequence
-                constitutes a gene or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be
-                encoded as gene, not as allele (i.e., here, not in c_allele). If referring to a known reference sequence
-                in a database, such as IMGT/GENE-DB, the relevant gene nomenclature should be followed (e.g., IGHG1).
-            example: IGHG1
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C gene
-        c_allele:
-            type: string
-            description: >
-                Allele of constant region gene. In cases in which it is contested whether a sequence constitutes a gene
-                or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be encoded as gene, not as
-                allele (i.e., not here, but in c_gene). If referring to a known reference sequence in a database, such
-                as IMGT/GENE-DB, the relevant gene nomenclature should be followed. For example, for IGHG1*01 an allele
-                string of 01 should be used (not 1).
-            example: 01
-            x-airr:
-                miairr: false
-                required: true
-                nullable: true
-                adc-api-optional: false
-                name: C allele
         sequence_alignment:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1444,6 +1444,13 @@ Rearrangement:
         locus:
             type: string
             description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
+            example: IGH
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: Locus
         v_call:
             type: string
             description: >
@@ -1456,7 +1463,44 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
+                name: V gene with allele
+        v_subgroup:
+            type: string
+            description: >
+                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4).
+            example: IGHV4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: V gene subgroup
+        v_gene:
+            type: string
+            description: >
+                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+            example: IGHV4-59
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
                 name: V gene
+        v_allele:
+            type: string
+            description: >
+                V allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHV4-59*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: V allele
         d_call:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1641,9 +1641,9 @@ Rearrangement:
         c_call:
             type: string
             description: >
-                C region gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene/allele nomenclature should be followed (e.g., IGHM*01).
-            example: IGHM*01
+                Constant region gene with allele. If referring to a known reference sequence in a database, such as
+                IMGT/GENE-DB, the relevant gene/allele nomenclature should be followed (e.g., IGHG1*01).
+            example: IGHG1*01
             x-airr:
                 miairr: true
                 required: true
@@ -1654,9 +1654,10 @@ Rearrangement:
         c_subgroup:
             type: string
             description: >
-                C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHM).
-            example: IGHM
+                Subgroup of the constant region gene. For immunoglobulins, this should be informative of the isotype
+                (e.g,, IgG). If referring to a known reference sequence in a database, such as IMGT/GENE-DB, the
+                relevant gene nomenclature should be followed (e.g., IGHG).
+            example: IGHG
             x-airr:
                 miairr: false
                 required: true
@@ -1666,9 +1667,12 @@ Rearrangement:
         c_gene:
             type: string
             description: >
-                C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHM).
-            example: IGHM
+                Constant region gene. For immunoglobulins, this should be informative about the subclass, if it exists
+                for the given isotype (e.g., IgG1 for IgG). In cases in which it is contested whether a sequence
+                constitutes a gene or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be
+                encoded as gene, not as allele (i.e., here, not in c_allele). If referring to a known reference sequence
+                in a database, such as IMGT/GENE-DB, the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
             x-airr:
                 miairr: false
                 required: true
@@ -1678,8 +1682,10 @@ Rearrangement:
         c_allele:
             type: string
             description: >
-                C allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed. For example, for IGHM*01 an allele
+                Allele of constant region gene. In cases in which it is contested whether a sequence constitutes a gene
+                or an allele (e.g., Ighg2a/c in M. musculus), the relevant information should be encoded as gene, not as
+                allele (i.e., not here, but in c_gene). If referring to a known reference sequence in a database, such
+                as IMGT/GENE-DB, the relevant gene nomenclature should be followed. For example, for IGHG1*01 an allele
                 string of 01 should be used (not 1).
             example: 01
             x-airr:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1514,6 +1514,43 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: D gene
+        d_subgroup:
+            type: string
+            description: >
+                D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: D gene subgroup
+        d_gene:
+            type: string
+            description: >
+                D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: V gene
+        d_allele:
+            type: string
+            description: >
+                D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: D allele
         j_call:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1443,14 +1443,26 @@ Rearrangement:
                 adc-api-optional: true
         locus:
             type: string
-            description: Gene locus (chain type). For example, IGH, IGI, IGK, IGL, TRA, TRB, TRD, or TRG.
+            enum:
+                - IGH
+                - IGI
+                - IGK
+                - IGL
+                - TRA
+                - TRB
+                - TRD
+                - TRG
+            description: >
+                Gene locus (chain type). Note that this field uses a controlled vocubulary that is meant to provide a
+                generic classification of the locus, not necessarily the correct designation according to a specific
+                nomenclature.
             example: IGH
             x-airr:
                 miairr: false
                 required: true
                 nullable: true
                 adc-api-optional: false
-                name: Locus
+                name: Gene locus
         v_call:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -927,7 +927,12 @@ NucleicAcidProcessing:
                 name: Protocol IDs
         pcr_target:
             type: array
-            description: Target locus information
+            description: >
+                If a PCR step was performed that specifically targets the IG/TR loci, the target and primer locations
+                need to be provided here. This field holds an array of PCRTarget objects, so that multiplex PCR setups
+                amplifying multiple loci at the same time can be annotated using one record per locus. PCR setups not
+                targeting any specific locus must not annotate this field but select the appropriate 
+                library_generation_method instead.
             items:
                 $ref: '#/PCRTarget'
         complete_sequences:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -946,8 +946,8 @@ NucleicAcidProcessing:
                 - "complete+untemplated"
             description: >
                 To be considered `complete`, the procedure used for library construction MUST generate sequences that
-                1) include the first V segment codon that encodes the mature polypeptide chain (i.e. after the
-                leader sequence) and 2) include the last complete codon of the J segment (i.e. 1 bp 5' of the J->C
+                1) include the first V gene codon that encodes the mature polypeptide chain (i.e. after the
+                leader sequence) and 2) include the last complete codon of the J gene (i.e. 1 bp 5' of the J->C
                 splice site) and 3) provide sequence information for all positions between 1) and 2). To be considered
                 `complete & untemplated`, the sections of the sequences defined in points 1) to 3) of the previous
                 sentence MUST be untemplated, i.e. MUST NOT overlap with the primers used in library preparation.
@@ -1434,7 +1434,7 @@ Rearrangement:
                 True if the V(D)J sequence is predicted to be productive.
         vj_in_frame:
             type: boolean
-            description: True if the V and J segment alignments are in-frame.
+            description: True if the V and J gene alignments are in-frame.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1589,8 +1589,8 @@ Rearrangement:
         np1:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the V segment and first D segment
-                or between the V and J segments.
+                Nucleotide sequence of the combined N/P region between the V gene and
+                first D gene alignment or between the V gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1604,8 +1604,8 @@ Rearrangement:
         np2:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between either the first D and J segments
-                or the first D and second D segments.
+                Nucleotide sequence of the combined N/P region between either the first D gene and J gene
+                alignments or the first D gene and second D gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1619,7 +1619,8 @@ Rearrangement:
         np3:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the second D segment and J segment.
+                Nucleotide sequence of the combined N/P region between the second D gene
+                and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1770,7 +1771,7 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the first or only D segment as defined by the alignment tool.
+                support for the first or only D gene as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1796,7 +1797,7 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the second D segment as defined by the alignment tool.
+                support for the second D gene as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1861,14 +1862,14 @@ Rearrangement:
         v_sequence_start:
             type: integer
             description: >
-                Start position of the V segment in the query sequence (1-based closed interval).
+                Start position of the V gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         v_sequence_end:
             type: integer
             description: >
-                End position of the V segment in the query sequence (1-based closed interval).
+                End position of the V gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1889,30 +1890,32 @@ Rearrangement:
         v_alignment_start:
             type: integer
             description: >
-                Start position in the V segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         v_alignment_end:
             type: integer
             description: >
-                End position in the V segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_start:
             type: integer
             description: >
-                Start position of the first or only D segment in the query sequence (1-based closed interval).
+                Start position of the first or only D gene in the query sequence.
+                (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_end:
             type: integer
             description: >
-                End position of the first or only D segment in the query sequence (1-based closed interval).
+                End position of the first or only D gene in the query sequence.
+                (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1920,7 +1923,7 @@ Rearrangement:
             type: integer
             description: >
                 Alignment start position in the D gene reference sequence for the first or only
-                D segment (1-based closed interval).
+                D gene (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1928,14 +1931,14 @@ Rearrangement:
             type: integer
             description: >
                 Alignment end position in the D gene reference sequence for the first or only
-                D segment (1-based closed interval).
+                D gene (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_start:
             type: integer
             description: >
-                Start position of the first or only D segment in both the sequence_alignment
+                Start position of the first or only D gene in both the sequence_alignment
                 and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
@@ -1943,7 +1946,7 @@ Rearrangement:
         d_alignment_end:
             type: integer
             description: >
-                End position of the first or only D segment in both the sequence_alignment
+                End position of the first or only D gene in both the sequence_alignment
                 and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
@@ -1951,14 +1954,14 @@ Rearrangement:
         d2_sequence_start:
             type: integer
             description: >
-                Start position of the second D segment in the query sequence (1-based closed interval).
+                Start position of the second D gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d2_sequence_end:
             type: integer
             description: >
-                End position of the second D segment in the query sequence (1-based closed interval).
+                End position of the second D gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1979,30 +1982,30 @@ Rearrangement:
         d2_alignment_start:
             type: integer
             description: >
-                Start position of the second D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the second D gene alignment in both the sequence_alignment and
+                germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d2_alignment_end:
             type: integer
             description: >
-                End position of the second D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the second D gene alignment in both the sequence_alignment and
+                germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_sequence_start:
             type: integer
             description: >
-                Start position of the J segment in the query sequence (1-based closed interval).
+                Start position of the J gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_sequence_end:
             type: integer
             description: >
-                End position of the J segment in the query sequence (1-based closed interval).
+                End position of the J gene in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2023,16 +2026,16 @@ Rearrangement:
         j_alignment_start:
             type: integer
             description: >
-                Start position of the J segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         j_alignment_end:
             type: integer
             description: >
-                End position of the J segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                End position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2123,7 +2126,7 @@ Rearrangement:
         v_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the V segment, including any
+                Aligned portion of query sequence assigned to the V gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2138,7 +2141,7 @@ Rearrangement:
         d_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the D segment, including any
+                Aligned portion of query sequence assigned to the first or only D gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2150,10 +2153,25 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        d2_sequence_alignment:
+            type: string
+            description: >
+                Aligned portion of query sequence assigned to the second D gene, including any
+                indel corrections or numbering spacers.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of the d2_sequence_alignment field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_sequence_alignment:
             type: string
             description: >
-                Aligned portion of query sequence assigned to the J segment, including any
+                Aligned portion of query sequence assigned to the J gene, including any
                 indel corrections or numbering spacers.
             x-airr:
                 miairr: false
@@ -2212,6 +2230,22 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        d2_germline_alignment:
+            type: string
+            description: >
+                Aligned D gene germline sequence spanning the same region
+                as the d2_sequence_alignment field and including the same set
+                of corrections and spacers (if any).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of the d2_germline_alignment field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_germline_alignment:
             type: string
             description: >
@@ -2259,77 +2293,77 @@ Rearrangement:
         np1_length:
             type: integer
             description: >
-                Number of nucleotides between the V and first D segment or between
-                the V and J segments.
+                Number of nucleotides between the V gene and first D gene alignments or
+                between the V gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np2_length:
             type: integer
             description: >
-                Number of nucleotides between either the first D and J segments
-                or the first D and second D segments.
+                Number of nucleotides between either the first D gene and J gene alignments
+                or the first D gene and second D gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np3_length:
             type: integer
             description: >
-                Number of nucleotides between the second D segment and J segment.
+                Number of nucleotides between the second D gene and J gene alignments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n1_length:
             type: integer
-            description: Number of untemplated nucleotides 5' of the first or only D segment.
+            description: Number of untemplated nucleotides 5' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n2_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the first or only D segment.
+            description: Number of untemplated nucleotides 3' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n3_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the second D segment.
+            description: Number of untemplated nucleotides 3' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3v_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the V segment.
+            description: Number of palindromic nucleotides 3' of the V gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5d_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the first or only D segment.
+            description: Number of palindromic nucleotides 5' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the first or only D segment.
+            description: Number of palindromic nucleotides 3' of the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5d2_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the second D segment.
+            description: Number of palindromic nucleotides 5' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d2_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the second D segment.
+            description: Number of palindromic nucleotides 3' of the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p5j_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the J segment.
+            description: Number of palindromic nucleotides 5' of the J gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2439,3 +2473,244 @@ Rearrangement:
             example: ENSEMBL, Homo sapiens build 90, 2017-10-01
             x-airr:
                 deprecated: true
+
+# A unique inferred clone object that has been constructed within a single data processing
+# for a single repertoire and a subset of its sequences and/or rearrangements.
+Clone:
+    discriminator: AIRR
+    type: object
+    required:
+        - clone_id
+        - repertoire_id
+        - germline_alignment
+    properties:
+        clone_id:
+            type: string
+            description: Identifier for the clone.
+            x-airr:
+                miairr: false
+                required: true
+        repertoire_id:
+            type: string
+            description: Identifier to the associated repertoire in study metadata.
+            x-airr:
+                miairr: false
+                required: true
+        data_processing_id:
+            type: string
+            description: Identifier of the data processing object in the repertoire metadata for this clone.
+            x-airr:
+                miairr: false
+                required: false
+        sequences:
+            type: array
+            items:
+                type: string
+            description: List of sequence_ids that are members of the clone.
+            x-airr:
+                miairr: false
+        rearrangements:
+            type: array
+            items:
+                type: string
+            description: List of rearrangement_ids that are members of the clone.
+            x-airr:
+                miairr: false
+        v_call:
+            type: string
+            description: >
+                V gene with allele of the inferred ancestral of the clone. For example, IGHV4-59*01.
+            example: IGHV4-59*01
+            x-airr:
+                miairr: false
+        d_call:
+            type: string
+            description: >
+                D gene with allele of the inferred ancestor of the clone. For example, IGHD3-10*01.
+            example: IGHD3-10*01
+            x-airr:
+                miairr: false
+        j_call:
+            type: string
+            description: >
+                J gene with allele of the inferred ancestor of the clone. For example, IGHJ4*02.
+            example: IGHJ4*02
+            x-airr:
+                miairr: false
+        junction:
+            type: string
+            description: >
+                Nucleotide sequence for the junction region of the inferred ancestor of the clone,
+                where the junction is defined as the CDR3 plus the two flanking conserved codons.
+        junction_aa:
+            type: string
+            description: >
+                Amino acid translation of the junction.
+            x-airr:
+                miairr: false
+        junction_length:
+            type: integer
+            description: Number of nucleotides in the junction.
+            x-airr:
+                miairr: false
+        junction_aa_length:
+            type: integer
+            description: Number of amino acids in junction_aa.
+            x-airr:
+                miairr: false
+        germline_alignment:
+            type: string
+            description: >
+                Assembled, aligned, full-length inferred ancestor of the clone spanning the same region
+                as the sequence_alignment field of nodes (typically the V(D)J region) and including the
+                same set of corrections and spacers (if any).
+            x-airr:
+                miairr: false
+                required: true
+        germline_alignment_aa:
+            type: string
+            description: >
+                Amino acid translation of germline_alignment.
+            x-airr:
+                miairr: false
+        v_alignment_start:
+            type: integer
+            description: >
+                Start position in the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        v_alignment_end:
+            type: integer
+            description: >
+                End position in the V gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        d_alignment_start:
+            type: integer
+            description: >
+                Start position of the D gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        d_alignment_end:
+            type: integer
+            description: >
+                End position of the D gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        j_alignment_start:
+            type: integer
+            description: >
+                Start position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        j_alignment_end:
+            type: integer
+            description: >
+                End position of the J gene alignment in both the sequence_alignment and germline_alignment
+                fields (1-based closed interval).
+            x-airr:
+                miairr: false
+        junction_start:
+            type: integer
+            description: Junction region start position in the alignment (1-based closed interval).
+            x-airr:
+                miairr: false
+        junction_end:
+            type: integer
+            description: Junction region end position in the alignment (1-based closed interval).
+            x-airr:
+                miairr: false
+        rearrangement_count:
+            type: integer
+            description: Number of rearrangements included in this clone
+            x-airr:
+                miairr: false
+        seed_id:
+            type: string
+            Description: rearrangment id for seed, null if no seed
+            x-airr:
+                miairr: false
+
+# 1-to-n relationship for a clone to its trees.
+Tree:
+    discriminator: AIRR
+    type: object
+    required:
+        - tree_id
+        - clone_id
+        - newick
+    properties:
+        tree_id:
+            type: string
+            description: Identifier for the tree.
+            x-airr:
+                miairr: false
+                required: true
+        clone_id:
+            type: string
+            description: Identifier for the clone.
+            x-airr:
+                miairr: false
+                required: true
+        newick:
+            type: string
+            description: Newick string of the tree edges.
+            x-airr:
+                miairr: false
+                required: true
+        nodes:
+            type: object
+            description: Dictionary of nodes in the tree, keyed by sequence_id string
+            x-airr:
+                miairr: false
+            additionalProperties:
+                $ref: '#/Node'
+
+# 1-to-n relationship between a tree and its nodes
+Node:
+    discriminator: AIRR
+    type: object
+    required:
+        - sequence_id
+    properties:
+        sequence_id:
+            type: string
+            description: >
+                Identifier for this node that matches the id in the newick string and, where possible,
+                the sequence_id in the source repertoire.
+            x-airr:
+                miairr: false
+                required: true
+        rearrangement_id:
+            type: string
+            description: >
+                Identifier for the Rearrangement object. May be identical to sequence_id,
+                but will usually be a univerally unique record locator for database applications.
+            x-airr:
+                miairr: false
+                required: false
+        sequence_alignment:
+            type: string
+            description: >
+                Nucleotide sequence of the node, aligned to the germline_alignment for this clone, including
+                including any indel corrections or spacers.
+            x-airr:
+                miairr: false
+        junction:
+            type: string
+            description: >
+                Junction region nucleotide sequence for the node, where the junction is defined as
+                the CDR3 plus the two flanking conserved codons.
+            x-airr:
+                miairr: false
+        junction_aa:
+            type: string
+            description: >
+                Amino acid translation of the junction.
+            x-airr:
+                miairr: false

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1360,7 +1360,7 @@ Alignment:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
         data_processing_id:
             type: string
             description: >
@@ -1453,7 +1453,7 @@ Rearrangement:
                 - TRD
                 - TRG
             description: >
-                Gene locus (chain type). Note that this field uses a controlled vocubulary that is meant to provide a
+                Gene locus (chain type). Note that this field uses a controlled vocabulary that is meant to provide a
                 generic classification of the locus, not necessarily the correct designation according to a specific
                 nomenclature.
             example: IGH

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2396,7 +2396,7 @@ Rearrangement:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
             x-airr:
                 miairr: false
                 required: true

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1614,6 +1614,43 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: C region
+        c_subgroup:
+            type: string
+            description: >
+                C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHM).
+            example: IGHM
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C gene subgroup
+        c_gene:
+            type: string
+            description: >
+                C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHM).
+            example: IGHM
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C gene
+        c_allele:
+            type: string
+            description: >
+                C allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHM*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: C allele
         sequence_alignment:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1513,7 +1513,7 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
-                name: D gene
+                name: D gene with allele
         d_subgroup:
             type: string
             description: >
@@ -1537,7 +1537,7 @@ Rearrangement:
                 required: true
                 nullable: true
                 adc-api-optional: false
-                name: V gene
+                name: D gene
         d_allele:
             type: string
             description: >
@@ -1563,7 +1563,44 @@ Rearrangement:
                 nullable: true
                 set: 6
                 subset: data (processed sequence)
+                name: J gene with allele
+        j_subgroup:
+            type: string
+            description: >
+                J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: J gene subgroup
+        j_gene:
+            type: string
+            description: >
+                J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
                 name: J gene
+        j_allele:
+            type: string
+            description: >
+                J allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHJ4*02 an allele
+                string of 02 should be used (not 1).
+            example: 02
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
+                adc-api-optional: false
+                name: J allele
         c_call:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1504,7 +1504,7 @@ Rearrangement:
         d_call:
             type: string
             description: >
-                D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
             example: IGHD3-10*01
             x-airr:
@@ -1517,7 +1517,7 @@ Rearrangement:
         d_subgroup:
             type: string
             description: >
-                D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                D subgroup of the first or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed (e.g., IGHD3).
             example: IGHD3
             x-airr:
@@ -1529,7 +1529,7 @@ Rearrangement:
         d_gene:
             type: string
             description: >
-                D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed (e.g., IGHD3-10).
             example: IGHD3-10
             x-airr:
@@ -1541,7 +1541,7 @@ Rearrangement:
         d_allele:
             type: string
             description: >
-                D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                First or only D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
                 the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
                 string of 01 should be used (not 1).
             example: 01
@@ -1551,6 +1551,43 @@ Rearrangement:
                 nullable: true
                 adc-api-optional: false
                 name: D allele
+        d2_call:
+            type: string
+            description: >
+                Second D gene with allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene/allele nomenclature should be followed (e.g., IGHD3-10*01).
+            example: IGHD3-10*01
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_subgroup:
+            type: string
+            description: >
+                D subgroup of the second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_gene:
+            type: string
+            description: >
+                Second D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_allele:
+            type: string
+            description: >
+                Second D allele. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed. For example, for IGHD3-10*01 an allele
+                string of 01 should be used (not 1).
+            example: 01
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         j_call:
             type: string
             description: >
@@ -1713,7 +1750,8 @@ Rearrangement:
         np1:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the V and D segments or V and J segments.
+                Nucleotide sequence of the combined N/P region between the V segment and first D segment
+                or between the V and J segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1727,7 +1765,8 @@ Rearrangement:
         np2:
             type: string
             description: >
-                Nucleotide sequence of the combined N/P region between the D and J segments.
+                Nucleotide sequence of the combined N/P region between either the first D and J segments
+                or the first D and second D segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1735,6 +1774,20 @@ Rearrangement:
             type: string
             description: >
                 Amino acid translation of the np2 field.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3:
+            type: string
+            description: >
+                Nucleotide sequence of the combined N/P region between the second D segment and J segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3_aa:
+            type: string
+            description: >
+                Amino acid translation of the np3 field.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1864,13 +1917,13 @@ Rearrangement:
                 adc-api-optional: true
         d_score:
             type: number
-            description: Alignment score for the D gene alignment.
+            description: Alignment score for the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_identity:
             type: number
-            description: Fractional identity for the D gene alignment.
+            description: Fractional identity for the first or only D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1878,13 +1931,39 @@ Rearrangement:
             type: number
             description: >
                 D gene alignment E-value, p-value, likelihood, probability or other similar measure of
-                support for the D gene assignment as defined by the alignment tool.
+                support for the first or only D segment as defined by the alignment tool.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_cigar:
             type: string
-            description: CIGAR string for the D gene alignment.
+            description: CIGAR string for the first or only D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_score:
+            type: number
+            description: Alignment score for the second D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_identity:
+            type: number
+            description: Fractional identity for the second D gene alignment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_support:
+            type: number
+            description: >
+                D gene alignment E-value, p-value, likelihood, probability or other similar measure of
+                support for the second D segment as defined by the alignment tool.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_cigar:
+            type: string
+            description: CIGAR string for the second D gene alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -1987,43 +2066,89 @@ Rearrangement:
         d_sequence_start:
             type: integer
             description: >
-                Start position of the D segment in the query sequence (1-based closed interval).
+                Start position of the first or only D segment in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_sequence_end:
             type: integer
             description: >
-                End position of the D segment in the query sequence (1-based closed interval).
+                End position of the first or only D segment in the query sequence (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_germline_start:
             type: integer
             description: >
-                Alignment start position in the D gene reference sequence (1-based closed interval).
+                Alignment start position in the D gene reference sequence for the first or only
+                D segment (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_germline_end:
             type: integer
             description: >
-                Alignment end position in the D gene reference sequence (1-based closed interval).
+                Alignment end position in the D gene reference sequence for the first or only
+                D segment (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_start:
             type: integer
             description: >
-                Start position of the D segment in both the sequence_alignment and germline_alignment fields
-                (1-based closed interval).
+                Start position of the first or only D segment in both the sequence_alignment
+                and germline_alignment fields (1-based closed interval).
             x-airr:
                 miairr: false
                 adc-api-optional: true
         d_alignment_end:
             type: integer
             description: >
-                End position of the D segment in both the sequence_alignment and germline_alignment fields
+                End position of the first or only D segment in both the sequence_alignment
+                and germline_alignment fields (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_start:
+            type: integer
+            description: >
+                Start position of the second D segment in the query sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_sequence_end:
+            type: integer
+            description: >
+                End position of the second D segment in the query sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_start:
+            type: integer
+            description: >
+                Alignment start position in the second D gene reference sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_germline_end:
+            type: integer
+            description: >
+                Alignment end position in the second D gene reference sequence (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_alignment_start:
+            type: integer
+            description: >
+                Start position of the second D segment in both the sequence_alignment and germline_alignment fields
+                (1-based closed interval).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        d2_alignment_end:
+            type: integer
+            description: >
+                End position of the second D segment in both the sequence_alignment and germline_alignment fields
                 (1-based closed interval).
             x-airr:
                 miairr: false
@@ -2294,25 +2419,42 @@ Rearrangement:
                 adc-api-optional: false
         np1_length:
             type: integer
-            description: Number of nucleotides between the V and D segments or V and J segments.
+            description: >
+                Number of nucleotides between the V and first D segment or between
+                the V and J segments.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         np2_length:
             type: integer
-            description: Number of nucleotides between the D and J segments.
+            description: >
+                Number of nucleotides between either the first D and J segments
+                or the first D and second D segments.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        np3_length:
+            type: integer
+            description: >
+                Number of nucleotides between the second D segment and J segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n1_length:
             type: integer
-            description: Number of untemplated nucleotides 5' of the D segment.
+            description: Number of untemplated nucleotides 5' of the first or only D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         n2_length:
             type: integer
-            description: Number of untemplated nucleotides 3' of the D segment.
+            description: Number of untemplated nucleotides 3' of the first or only D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        n3_length:
+            type: integer
+            description: Number of untemplated nucleotides 3' of the second D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2324,13 +2466,25 @@ Rearrangement:
                 adc-api-optional: true
         p5d_length:
             type: integer
-            description: Number of palindromic nucleotides 5' of the D segment.
+            description: Number of palindromic nucleotides 5' of the first or only D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
         p3d_length:
             type: integer
-            description: Number of palindromic nucleotides 3' of the D segment.
+            description: Number of palindromic nucleotides 3' of the first or only D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        p5d2_length:
+            type: integer
+            description: Number of palindromic nucleotides 5' of the second D segment.
+            x-airr:
+                miairr: false
+                adc-api-optional: true
+        p3d2_length:
+            type: integer
+            description: Number of palindromic nucleotides 3' of the second D segment.
             x-airr:
                 miairr: false
                 adc-api-optional: true
@@ -2446,4 +2600,3 @@ Rearrangement:
             example: ENSEMBL, Homo sapiens build 90, 2017-10-01
             x-airr:
                 deprecated: true
-


### PR DESCRIPTION
This is a clone of #295, with the following changes:

* Removal of v/d/j fields `*_subgroup`, `*_gene` and `*_allele`, which have been pushed back to v2.0.
* Incorporation of additional gene nomenclature text from @williamdlees in Rearrangement docs.
* An attempt to resolve the impasse on the inclusion of examples in the existing `*_call` fields.

The main purpose here is to resolve #268, adding the extra fields to Rearrangement need to properly support IMGT adding Rearrangement support to IMGT/V-QUEST.

I think we can also resolve #309, but I didn't add those two fields yet, as I think they need discussion first.