### PR TITLE
clone schema Olmsted validation

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -2502,7 +2502,6 @@ Clone:
     type: object
     required:
         - clone_id
-        - repertoire_id
         - germline_alignment
     properties:
         clone_id:
@@ -2517,12 +2516,16 @@ Clone:
             x-airr:
                 miairr: false
                 required: true
+                nullable: true
+                adc-api-optional: false
         data_processing_id:
             type: string
             description: Identifier of the data processing object in the repertoire metadata for this clone.
             x-airr:
                 miairr: false
-                required: false
+                required: true
+                nullable: true
+                adc-api-optional: false
         sequences:
             type: array
             items:
@@ -2653,7 +2656,7 @@ Clone:
                 miairr: false
         seed_id:
             type: string
-            Description: rearrangment id for seed, null if no seed
+            Description: sequence_id of the seed sequence. Empty string (or null) if there is no seed sequence.
             x-airr:
                 miairr: false
 
@@ -2711,7 +2714,7 @@ Node:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
             x-airr:
                 miairr: false
                 required: false

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -2502,7 +2502,6 @@ Clone:
     type: object
     required:
         - clone_id
-        - repertoire_id
         - germline_alignment
     properties:
         clone_id:
@@ -2517,12 +2516,16 @@ Clone:
             x-airr:
                 miairr: false
                 required: true
+                nullable: true
+                adc-api-optional: false
         data_processing_id:
             type: string
             description: Identifier of the data processing object in the repertoire metadata for this clone.
             x-airr:
                 miairr: false
-                required: false
+                required: true
+                nullable: true
+                adc-api-optional: false
         sequences:
             type: array
             items:
@@ -2653,7 +2656,7 @@ Clone:
                 miairr: false
         seed_id:
             type: string
-            Description: rearrangment id for seed, null if no seed
+            Description: sequence_id of the seed sequence. Empty string (or null) if there is no seed sequence.
             x-airr:
                 miairr: false
 
@@ -2711,7 +2714,7 @@ Node:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
             x-airr:
                 miairr: false
                 required: false

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2502,7 +2502,6 @@ Clone:
     type: object
     required:
         - clone_id
-        - repertoire_id
         - germline_alignment
     properties:
         clone_id:
@@ -2512,19 +2511,21 @@ Clone:
                 miairr: false
                 required: true
         repertoire_id:
-            type:
-                - string
-                - "null"
+            type: string
             description: Identifier to the associated repertoire in study metadata.
             x-airr:
                 miairr: false
                 required: true
+                nullable: true
+                adc-api-optional: false
         data_processing_id:
             type: string
             description: Identifier of the data processing object in the repertoire metadata for this clone.
             x-airr:
                 miairr: false
-                required: false
+                required: true
+                nullable: true
+                adc-api-optional: false
         sequences:
             type: array
             items:
@@ -2654,10 +2655,8 @@ Clone:
             x-airr:
                 miairr: false
         seed_id:
-            type:
-                - string
-                - "null"
-            Description: rearrangment id for seed, null if no seed
+            type: string
+            Description: sequence_id of the seed sequence. Empty string (or null) if there is no seed sequence.
             x-airr:
                 miairr: false
 
@@ -2715,7 +2714,7 @@ Node:
             type: string
             description: >
                 Identifier for the Rearrangement object. May be identical to sequence_id,
-                but will usually be a univerally unique record locator for database applications.
+                but will usually be a universally unique record locator for database applications.
             x-airr:
                 miairr: false
                 required: false

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2352,7 +2352,9 @@ Clone:
                 miairr: false
                 required: true
         repertoire_id:
-            type: string
+            type:
+                - string
+                - "null"
             description: Identifier to the associated repertoire in study metadata.
             x-airr:
                 miairr: false

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2492,7 +2492,9 @@ Clone:
             x-airr:
                 miairr: false
         seed_id:
-            type: string
+            type:
+                - string
+                - "null"
             Description: rearrangment id for seed, null if no seed
             x-airr:
                 miairr: false


### PR DESCRIPTION
Working on validating clones using the AIRR clones and trees schema in Olmsted!

It seems like the way null/None values are allowed in the AIRR schema at the moment is via [the `x-airr.nullable` field](https://github.com/eharkins/airr-standards/blob/b109492b17971ed8001a911131bf5e77772602f5/specs/airr-schema.yaml#L114). Since in Olmsted, I am just loading in the Clones portion of the yaml schema into my python script and validating directly from there with the [jsonschema](https://python-jsonschema.readthedocs.io/en/stable/) package, I can't make use of that field to allow null values for certain attributes.

The two ways I can think of to allow null values instead of using `x-airr.nullable` are:
1. The way I have done in this pull request
2. [Extending the validator](https://python-jsonschema.readthedocs.io/en/stable/validate/#validating-with-additional-types) to take null in place of any field of type string in the schema. 

Some examples of things I would like to leave as null:
- `Clone.repertoire_id`, since we aren't yet adopting the AIRR Repertoire object / concept in Olmsted; because this is a required field in the AIRR schema here, I understand if you don't want to allow null values for it.
- `Clone.seed_id`: the [description](https://github.com/airr-community/airr-standards/compare/master...eharkins:olmsted_clones_validation?expand=1#diff-7d67e9142fe90cadc6c257313a117f65R2660) says 
> null if no seed

so it seems at least worth adding the `x-airr.nullable` for you own validation purposes.

Thanks!