### PR TITLE
Add complete_vdj boolean to schema to identify truncated alignments

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1483,6 +1483,8 @@ Rearrangement:
                 sequence_alignment includes both the first V gene codon that encodes the
                 mature polypeptide chain (i.e., after the leader sequence) and the last
                 complete codon of the J gene (i.e., before the J-C splice site).
+                This does not require an absence of deletions within the internal
+                FWR and CDR regions of the alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1468,7 +1468,7 @@ Rearrangement:
         complete_vdj:
             type: boolean
             description: >
-                True if query nucleotide sequence spans the entire V(D)J region. Meaning, the sequence
+                True if the sequence alignment spans the entire V(D)J region. Meaning, sequence_alignment
                 includes both the first V gene codon that encodes the mature polypeptide chain
                 (i.e., after the leader sequence) and the last complete codon of the
                 J gene (i.e., before the J-C splice site).

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1468,10 +1468,13 @@ Rearrangement:
         complete_vdj:
             type: boolean
             description: >
-                True if the sequence alignment spans the entire V(D)J region. Meaning, sequence_alignment
-                includes both the first V gene codon that encodes the mature polypeptide chain
-                (i.e., after the leader sequence) and the last complete codon of the
-                J gene (i.e., before the J-C splice site).
+                True if the sequence alignment spans the entire V(D)J region. Meaning,
+                sequence_alignment includes both the first V gene codon that encodes the
+                mature polypeptide chain (i.e., after the leader sequence) and the last
+                complete codon of the J gene (i.e., before the J-C splice site).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         locus:
             type: string
             enum:

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1465,6 +1465,13 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        complete_vdj:
+            type: boolean
+            description: >
+                True if query nucleotide sequence spans the entire V(D)J region. Meaning, the sequence
+                includes both the first V gene codon that encodes the mature polypeptide chain
+                (i.e., after the leader sequence) and the last complete codon of the
+                J gene (i.e., before the J-C splice site).
         locus:
             type: string
             enum:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1483,6 +1483,8 @@ Rearrangement:
                 sequence_alignment includes both the first V gene codon that encodes the
                 mature polypeptide chain (i.e., after the leader sequence) and the last
                 complete codon of the J gene (i.e., before the J-C splice site).
+                This does not require an absence of deletions within the internal
+                FWR and CDR regions of the alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1468,7 +1468,7 @@ Rearrangement:
         complete_vdj:
             type: boolean
             description: >
-                True if query nucleotide sequence spans the entire V(D)J region. Meaning, the sequence
+                True if the sequence alignment spans the entire V(D)J region. Meaning, sequence_alignment
                 includes both the first V gene codon that encodes the mature polypeptide chain
                 (i.e., after the leader sequence) and the last complete codon of the
                 J gene (i.e., before the J-C splice site).

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1468,10 +1468,13 @@ Rearrangement:
         complete_vdj:
             type: boolean
             description: >
-                True if the sequence alignment spans the entire V(D)J region. Meaning, sequence_alignment
-                includes both the first V gene codon that encodes the mature polypeptide chain
-                (i.e., after the leader sequence) and the last complete codon of the
-                J gene (i.e., before the J-C splice site).
+                True if the sequence alignment spans the entire V(D)J region. Meaning,
+                sequence_alignment includes both the first V gene codon that encodes the
+                mature polypeptide chain (i.e., after the leader sequence) and the last
+                complete codon of the J gene (i.e., before the J-C splice site).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         locus:
             type: string
             enum:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1465,6 +1465,13 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        complete_vdj:
+            type: boolean
+            description: >
+                True if query nucleotide sequence spans the entire V(D)J region. Meaning, the sequence
+                includes both the first V gene codon that encodes the mature polypeptide chain
+                (i.e., after the leader sequence) and the last complete codon of the
+                J gene (i.e., before the J-C splice site).
         locus:
             type: string
             enum:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1483,6 +1483,8 @@ Rearrangement:
                 sequence_alignment includes both the first V gene codon that encodes the
                 mature polypeptide chain (i.e., after the leader sequence) and the last
                 complete codon of the J gene (i.e., before the J-C splice site).
+                This does not require an absence of deletions within the internal
+                FWR and CDR regions of the alignment.
             x-airr:
                 miairr: false
                 adc-api-optional: true

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1468,7 +1468,7 @@ Rearrangement:
         complete_vdj:
             type: boolean
             description: >
-                True if query nucleotide sequence spans the entire V(D)J region. Meaning, the sequence
+                True if the sequence alignment spans the entire V(D)J region. Meaning, sequence_alignment
                 includes both the first V gene codon that encodes the mature polypeptide chain
                 (i.e., after the leader sequence) and the last complete codon of the
                 J gene (i.e., before the J-C splice site).

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1468,10 +1468,13 @@ Rearrangement:
         complete_vdj:
             type: boolean
             description: >
-                True if the sequence alignment spans the entire V(D)J region. Meaning, sequence_alignment
-                includes both the first V gene codon that encodes the mature polypeptide chain
-                (i.e., after the leader sequence) and the last complete codon of the
-                J gene (i.e., before the J-C splice site).
+                True if the sequence alignment spans the entire V(D)J region. Meaning,
+                sequence_alignment includes both the first V gene codon that encodes the
+                mature polypeptide chain (i.e., after the leader sequence) and the last
+                complete codon of the J gene (i.e., before the J-C splice site).
+            x-airr:
+                miairr: false
+                adc-api-optional: true
         locus:
             type: string
             enum:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1465,6 +1465,13 @@ Rearrangement:
             x-airr:
                 miairr: false
                 adc-api-optional: true
+        complete_vdj:
+            type: boolean
+            description: >
+                True if query nucleotide sequence spans the entire V(D)J region. Meaning, the sequence
+                includes both the first V gene codon that encodes the mature polypeptide chain
+                (i.e., after the leader sequence) and the last complete codon of the
+                J gene (i.e., before the J-C splice site).
         locus:
             type: string
             enum:


### PR DESCRIPTION
Added the `complete_vdj` boolean to the schema, per discussion in #309.  I preserved a lot of the language from `NucleicAcidProcessing::complete_sequences`, but it's not exactly the same:

```
complete_vdj:
    type: boolean
    description: >
        True if query nucleotide sequence spans the entire V(D)J region. 
        Meaning, the sequence includes both the first V gene codon that 
        encodes the mature polypeptide chain (i.e., after the leader sequence) 
        and the last complete codon of the J gene 
        (i.e., before the J-C splice site).
```

One concern I have it how to deal with alignments that are not complete according to his definition, because they haven't included mismatches at the 5'/3' ends, despite having a query sequence length that extends further in either direction. So, I referenced the query sequence (`sequence`) instead of the alignment (`sequence_alignment`). Not sure about this.

We should also verify that this definition is consistent with the `full_length` column of the cellranger-vdj annotation CSV.