### PR TITLE
remove pair_id

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -2412,20 +2412,6 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: Read count
-        pair_id:
-            type: string
-            description: >
-                Valid sequence_id that was determined by experimental or computational means to
-                be associated with the current Rearrangement on the cellular level.
-            example: ABC314159
-            x-airr:
-                miairr: true
-                required: true
-                nullable: true
-                adc-api-optional: false
-                set: 6
-                subset: data (processed sequence)
-                name: Paired-chain index
         cell_id:
             type: string
             description: >

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -2412,20 +2412,6 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: Read count
-        pair_id:
-            type: string
-            description: >
-                Valid sequence_id that was determined by experimental or computational means to
-                be associated with the current Rearrangement on the cellular level.
-            example: ABC314159
-            x-airr:
-                miairr: true
-                required: true
-                nullable: true
-                adc-api-optional: false
-                set: 6
-                subset: data (processed sequence)
-                name: Paired-chain index
         cell_id:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2412,20 +2412,6 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: Read count
-        pair_id:
-            type: string
-            description: >
-                Valid sequence_id that was determined by experimental or computational means to
-                be associated with the current Rearrangement on the cellular level.
-            example: ABC314159
-            x-airr:
-                miairr: true
-                required: true
-                nullable: true
-                adc-api-optional: false
-                set: 6
-                subset: data (processed sequence)
-                name: Paired-chain index
         cell_id:
             type: string
             description: >


### PR DESCRIPTION
fixes #273 

`pair_id` was an experimental field that was never in a released version of the schema, so no need to deprecate it, can just remove it.