### PR TITLE
Add OntoVoc to Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -276,12 +276,23 @@ for spec in tables:
     for k, v in properties.items():
         row = {}
         row['name'] = k
-        if v.get('type'):
-            row['type'] = v['type']
+        if v.get('type') == 'array':
+            if v['items'].get('$ref') is not None:
+                sn = v['items'].get('$ref').split('/')[-1]
+                row['type'] = '``array`` of :ref:`' + sn + ' <' + sn + 'Fields>`'
+            elif v['items'].get('type') is not None:
+                row['type'] = '``array`` of ``' + v['items']['type'] + '``'
+            else:
+                row['type'] = '``' + v['type'] + '``'
+        elif v.get('type'):
+            row['type'] = '``' + v['type'] + '``'
         elif v.get('$ref') == '#/Ontology':
-            row['type'] = 'Ontology object'
+            row['type'] = ':ref:`Ontology <OntoVoc>`'
+        elif v.get('$ref') is not None:
+            sn = v.get('$ref').split('/')[-1]
+            row['type'] = ':ref:`' + sn + ' <' + sn + 'Fields>`'
         else:
-            row['type'] = 'unknown'
+            row['type'] = '``unknown``'
         if v.get('x-airr') and v.get('x-airr').get('miairr'):
             row['miairr'] = 'required'
         else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'AIRR Standards'
-copyright = '2017-2019, AIRR Community'
+copyright = '2017-2020, AIRR Community'
 author = 'AIRR Community'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/datarep/metadata.rst
+++ b/docs/datarep/metadata.rst
@@ -182,10 +182,12 @@ Repertoire Fields
       - Description
     {%- for field in Repertoire_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _StudyFields:
 
 Study Fields
 ------------------------------
@@ -200,10 +202,12 @@ Study Fields
       - Description
     {%- for field in Study_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _SubjectFields:
 
 Subject Fields
 ------------------------------
@@ -218,10 +222,12 @@ Subject Fields
       - Description
     {%- for field in Subject_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _DiagnosisFields:
 
 Diagnosis Fields
 ------------------------------
@@ -236,10 +242,12 @@ Diagnosis Fields
       - Description
     {%- for field in Diagnosis_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _SampleFields:
 
 Sample Fields
 ------------------------------
@@ -254,10 +262,12 @@ Sample Fields
       - Description
     {%- for field in Sample_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _CellProcessingFields:
 
 Tissue and Cell Processing Fields
 ---------------------------------
@@ -272,10 +282,12 @@ Tissue and Cell Processing Fields
       - Description
     {%- for field in CellProcessing_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _NucleicAcidProcessingFields:
 
 Nucleic Acid Processing Fields
 ---------------------------------
@@ -290,10 +302,12 @@ Nucleic Acid Processing Fields
       - Description
     {%- for field in NucleicAcidProcessing_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _PCRTargetFields:
 
 PCR Target Locus Fields
 ---------------------------------
@@ -308,10 +322,12 @@ PCR Target Locus Fields
       - Description
     {%- for field in PCRTarget_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _RawSequenceDataFields:
 
 Raw Sequence Data Fields
 ---------------------------------
@@ -326,10 +342,12 @@ Raw Sequence Data Fields
       - Description
     {%- for field in RawSequenceData_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _SequencingRunFields:
 
 Sequencing Run Fields
 ---------------------------------
@@ -344,10 +362,12 @@ Sequencing Run Fields
       - Description
     {%- for field in SequencingRun_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
+
+.. _DataProcessingFields:
 
 Data Processing Fields
 ---------------------------------
@@ -362,14 +382,8 @@ Data Processing Fields
       - Description
     {%- for field in DataProcessing_schema %}
     * - ``{{ field.name }}``
-      - ``{{ field.type }}``
+      - {{ field.type }}
       - ``{{ field.miairr }}``
       - {{ field.description | trim }}
     {%- endfor %}
 
-References
------------------------------
-
-The metadata API defines the set of fields in the metadata. INCLUDE LINK.
-
-An example metadata file is included in the repository as ``florian.airr.yaml``.

--- a/docs/ontovoc/introduction_ontovoc.rst
+++ b/docs/ontovoc/introduction_ontovoc.rst
@@ -34,10 +34,10 @@ Approved Ontologies
 -  Species (``organism``, :ref:`Subject <SubjectFields>`) (``cell_species``, :ref:`Tissue and Cell Processing <CellProcessingFields>`)
 
    -  NCBITAXON_
-   - root node
+   -  root node
    
-      - name: ``Gnathostomata``
-      - ID: ``7776``
+      -  name: ``Gnathostomata``
+      -  ID: ``7776``
       
    -  license: UMLS
    -  latest release: 2018-07-06
@@ -75,10 +75,10 @@ Approved Ontologies
 -  Cell subset (``cell_subset``, :ref:`Tissue and Cell Processing <CellProcessingFields>`)
 
    -  CellOntology_
-   - root node
+   -  root node
    
-      - name: ``lymphocyte``
-      - id: ``CL_0000542``
+      -  name: ``lymphocyte``
+      -  id: ``CL_0000542``
       
    -  license: `CC BY`_
    -  latest release: 2018-07-11

--- a/docs/ontovoc/introduction_ontovoc.rst
+++ b/docs/ontovoc/introduction_ontovoc.rst
@@ -34,6 +34,11 @@ Approved Ontologies
 -  Species (``organism``, :ref:`Subject <SubjectFields>`) (``cell_species``, :ref:`Tissue and Cell Processing <CellProcessingFields>`)
 
    -  NCBITAXON_
+   - root node
+   
+      - name: ``Gnathostomata``
+      - ID: ``7776``
+      
    -  license: UMLS
    -  latest release: 2018-07-06
    -  maintainer: NCBI (info@ncbi.nlm.nih.gov)
@@ -70,6 +75,11 @@ Approved Ontologies
 -  Cell subset (``cell_subset``, :ref:`Tissue and Cell Processing <CellProcessingFields>`)
 
    -  CellOntology_
+   - root node
+   
+      - name: ``lymphocyte``
+      - id: ``CL_0000542``
+      
    -  license: `CC BY`_
    -  latest release: 2018-07-11
    -  maintainer: Alexander Diehl, Buffalo, NY, US

--- a/docs/ontovoc/introduction_ontovoc.rst
+++ b/docs/ontovoc/introduction_ontovoc.rst
@@ -38,6 +38,19 @@ Approved Ontologies
    -  latest release: 2018-07-06
    -  maintainer: NCBI (info@ncbi.nlm.nih.gov)
 
+-  Age unit (``age_unit``, :ref:`Subject <SubjectFields>`)
+   -  UO_
+   -  **draft**
+   -  root node
+
+      -  name: ``time unit``
+      -  ID: ``UO_0000003``
+      -  path: ``unit/time unit``
+
+   -  license: `CC BY`_ (per GH repo)
+   -  latest release: 2019-03-29
+   -  maintainer: unknown, repo: https://github.com/bio-ontology-research-group/unit-ontology
+
 -  Diagnosis (``disease_diagnosis``, :ref:`Diagnosis <DiagnosisFields>`)
 
    -  DOID_
@@ -47,7 +60,7 @@ Approved Ontologies
       -  ID: ``DOID:4``
       -  path: ``/disease``
 
-   -  License: `CC BY`_
+   -  license: `CC BY`_
    -  latest release: 2018-03-02
    -  maintainer: Lynn Schriml, U Maryland, MD, US
       (lynn.schriml@gmail.com)
@@ -72,9 +85,9 @@ Approved Ontologies
          anatomical entity/anatomical structure/multicellular anatomical
          structure``
 
-   -  License: `CC BY`_
+   -  license: `CC BY`_
    -  latest release: 2018-10-15
-   -  Maintainer: Chris Mungall, LBL, CA, US
+   -  maintainer: Chris Mungall, LBL, CA, US
       (cjmungall@lbl.gov)
 
 Topics
@@ -94,3 +107,4 @@ Topics
 .. _CellOntology: https://www.ebi.ac.uk/ols/ontologies/CL
 .. _Uberon: https://www.ebi.ac.uk/ols/ontologies/UBERON
 .. _NCIT: https://www.ebi.ac.uk/ols/ontologies/ncit
+.. _UO: https://www.ebi.ac.uk/ols/ontologies/UO

--- a/docs/ontovoc/introduction_ontovoc.rst
+++ b/docs/ontovoc/introduction_ontovoc.rst
@@ -1,0 +1,23 @@
+.. _OntoVoc:
+
+=====================================
+AIRR Ontologies and Vocabularies Team
+=====================================
+
+Summary
+=======
+
+The "Ontologies and Vocabularies Team" was formed as a joint interest
+group of the Common Repository (ComRepo) and the Minimal Standards
+(MiniStd) working groups of the AIRR Community. The long-term aim of
+the Team is to define standard vocabularies and ontologies to be used
+by AIRR-compliant databases.
+
+
+Topics
+======
+
+.. toctree::
+   :maxdepth: 2
+
+   Report Sprint 11/2018 <report_sprint_2018-11>

--- a/docs/ontovoc/introduction_ontovoc.rst
+++ b/docs/ontovoc/introduction_ontovoc.rst
@@ -13,6 +13,54 @@ group of the Common Repository (ComRepo) and the Minimal Standards
 the Team is to define standard vocabularies and ontologies to be used
 by AIRR-compliant databases.
 
+Approved Ontologies
+===================
+
+-  Species (``organism``, :ref:`Subject <SubjectFields>`) (``cell_species``, :ref:`Tissue and Cell Processing <CellProcessingFields>`)
+
+   -  NCBITAXON_
+   -  license: UMLS
+   -  latest release: 2018-07-06
+   -  maintainer: NCBI (info@ncbi.nlm.nih.gov)
+
+-  Diagnosis (``disease_diagnosis``, :ref:`Diagnosis <DiagnosisFields>`)
+
+   -  DOID_
+   -  root node
+
+      -  name: ``disease``
+      -  ID: ``DOID:4``
+      -  path: ``/disease``
+
+   -  License: `CC BY`_
+   -  latest release: 2018-03-02
+   -  maintainer: Lynn Schriml, U Maryland, MD, US
+      (lynn.schriml@gmail.com)
+   -  notes: Features ICD cross-reference
+
+-  Cell subset (``cell_subset``, :ref:`Tissue and Cell Processing <CellProcessingFields>`)
+
+   -  CellOntology_
+   -  license: `CC BY`_
+   -  latest release: 2018-07-11
+   -  maintainer: Alexander Diehl, Buffalo, NY, US
+      (addiehl@buffalo.edu)
+
+-  Tissue (``tissue``, :ref:`Sample <SampleFields>`)
+
+   -  Uberon_
+   -  root node
+
+      -  name: ``multicellular anatomical structure``
+      -  ID: ``UBERON:0010000``
+      -  path: ``/BFO_0000002/BFO_0000004/anatomical entity/material
+         anatomical entity/anatomical structure/multicellular anatomical
+         structure``
+
+   -  License: `CC BY`_
+   -  latest release: 2018-10-15
+   -  Maintainer: Chris Mungall, LBL, CA, US
+      (cjmungall@lbl.gov)
 
 Topics
 ======
@@ -21,3 +69,12 @@ Topics
    :maxdepth: 2
 
    Report Sprint 11/2018 <report_sprint_2018-11>
+
+.. Links
+
+.. _CC0: https://creativecommons.org/publicdomain/zero/1.0/
+.. _`CC BY`: https://creativecommons.org/licenses/by/4.0/
+.. _NCBITAXON: https://bioportal.bioontology.org/ontologies/NCBITAXON
+.. _DOID: https://bioportal.bioontology.org/ontologies/DOID
+.. _CellOntology: https://bioportal.bioontology.org/ontologies/CL
+.. _Uberon: https://bioportal.bioontology.org/ontologies/UBERON

--- a/docs/ontovoc/introduction_ontovoc.rst
+++ b/docs/ontovoc/introduction_ontovoc.rst
@@ -39,6 +39,7 @@ Approved Ontologies
    -  maintainer: NCBI (info@ncbi.nlm.nih.gov)
 
 -  Age unit (``age_unit``, :ref:`Subject <SubjectFields>`)
+
    -  UO_
    -  **draft**
    -  root node

--- a/docs/ontovoc/introduction_ontovoc.rst
+++ b/docs/ontovoc/introduction_ontovoc.rst
@@ -16,6 +16,21 @@ by AIRR-compliant databases.
 Approved Ontologies
 ===================
 
+-  Study type (``Study type``, :ref:`Study <StudyFields>`)
+
+   -  NCIT_
+   -  **draft**
+   -  root node
+
+      -  name: ``Study``
+      -  ID: ``C63536``
+      -  path: ``/Activity/Clinical or Research Activity/Research Activity/Study``
+
+   -  License: Public domain, credit of NCI is requested
+   -  latest release: 2019-09-09
+   -  maintainer: NCI (ncicbiitappssupport@mail.nih.gov)
+
+
 -  Species (``organism``, :ref:`Subject <SubjectFields>`) (``cell_species``, :ref:`Tissue and Cell Processing <CellProcessingFields>`)
 
    -  NCBITAXON_
@@ -74,7 +89,8 @@ Topics
 
 .. _CC0: https://creativecommons.org/publicdomain/zero/1.0/
 .. _`CC BY`: https://creativecommons.org/licenses/by/4.0/
-.. _NCBITAXON: https://bioportal.bioontology.org/ontologies/NCBITAXON
-.. _DOID: https://bioportal.bioontology.org/ontologies/DOID
-.. _CellOntology: https://bioportal.bioontology.org/ontologies/CL
-.. _Uberon: https://bioportal.bioontology.org/ontologies/UBERON
+.. _NCBITAXON: https://www.ebi.ac.uk/ols/ontologies/NCBITAXON
+.. _DOID: https://www.ebi.ac.uk/ols/ontologies/DOID
+.. _CellOntology: https://www.ebi.ac.uk/ols/ontologies/CL
+.. _Uberon: https://www.ebi.ac.uk/ols/ontologies/UBERON
+.. _NCIT: https://www.ebi.ac.uk/ols/ontologies/ncit

--- a/docs/ontovoc/report_sprint_2018-11.rst
+++ b/docs/ontovoc/report_sprint_2018-11.rst
@@ -108,6 +108,12 @@ Completed
 -  Diagnosis (``disease_diagnosis``)
 
    -  DOID_
+   -  root node
+
+      -  name: ``disease``
+      -  ID: ``DOID:4``
+      -  path: ``/disease``
+
    -  License: `CC BY`_
    -  latest release: 2018-03-02
    -  maintainer: Lynn Schriml, U Maryland, MD, US
@@ -125,6 +131,14 @@ Completed
 -  Tissue (``tissue``)
 
    -  Uberon_
+   -  root node
+
+      -  name: ``multicellular anatomical structure``
+      -  ID: ``UBERON:0010000``
+      -  path: ``/BFO_0000002/BFO_0000004/anatomical entity/material
+         anatomical entity/anatomical structure/multicellular anatomical
+         structure``
+
    -  License: `CC BY`_
    -  latest release: 2018-10-15
    -  Maintainer: Chris Mungall, LBL, CA, US

--- a/docs/ontovoc/report_sprint_2018-11.rst
+++ b/docs/ontovoc/report_sprint_2018-11.rst
@@ -1,0 +1,253 @@
+===============================
+OntoVoc Report - Sprint 11/2018
+===============================
+
+Objectives
+==========
+
+The objectives of this first sprint in November 2018 were to:
+
+1. define criteria for suitable ontologies
+
+2. identify ontologies for five fields/keywords of the MiAIRR data
+   standard and
+
+3. assess technical aspects of ontology integration into databases
+
+
+General Considerations
+======================
+
+The Team initially discussed an approach where only vocabularies (i.e.
+lists of terms) and not ontologies (i.e. many terms connected by
+predicates) would have been defined. These vocabularies would have been
+derived from ontologies, but this process would not necessarily have
+been reversible. The notion at this time point was, that such an
+approach would allow to solve a number of problems like combining
+multiple sources and removing duplicated leaves. However, after some
+discussions this approach was effectively abandoned for a number of
+reasons:
+
+-  It would discard the UID for an entity. As the UID (in contrast to
+   the name string) is guaranteed to be stable and unique, it
+   facilitates updates, linking and information representation, all of
+   which would otherwise be lost.
+-  In general, it will be more sustainable to work with the maintainers
+   of an existing ontology to include entities/terms, than just dumping
+   their terms into a list and adding new ones.
+-  Well-designed ontologies will not contain duplicated entities,
+   although they might appear to do so in a simple browsers (i.e. this
+   is an artifact of representation). Ontologies that actually do
+   contain duplicates are excluded by criterium `(2)`_.
+
+
+Criteria for Ontologies
+=======================
+
+Criteria
+--------
+
+Ontologies used within AIRR standards
+
+.. _ONTO_CRIT_1:
+1. MUST [1]_ cover the majority of the required terms, but complete
+   coverage is OPTIONAL
+
+.. _ONTO_CRIT_2:
+2. MUST have a structure that is scientifically correct and logically
+   coherent
+
+.. _ONTO_CRIT_3:
+3. MUST NOT feature complexity that makes it hard to use for queries
+   and data representation
+
+.. _ONTO_CRIT_4:
+4. SHOULD already be widely adopted
+
+.. _ONTO_CRIT_5:
+5. MUST be actively maintained
+
+.. _ONTO_CRIT_6:
+6. MUST be available under a free license
+
+Comments on criteria:
+
+-  ad `(1)`_: For most fields it will be difficult to find complete and
+   accurate ontologies. Therefore picking the best available ontology
+   and working with its maintainers to include missing terms is expected
+   to be the most sustainable approach.
+-  ad `(5)`_: This requirement follows from `(1)`_, as there needs to be
+   a way for term requests.
+-  ad `(6)`_: A number of ontologies need to be licensed from their
+   respective copyright holders. This results in potential barriers for
+   implementation and distribution of such ontologies. Therefore only
+   ontologies available under a free license are considered suitable for
+   AIRR-compliant databases. The list of suitable licenses is not final,
+   but includes: CC0_ and `CC BY`_.
+
+.. _`(1)`: ONTO_CRIT_1_
+.. _`(5)`: ONTO_CRIT_5_
+.. _`(6)`: ONTO_CRIT_6_
+
+
+Selected Ontologies
+===================
+
+(designations are MiAIRR field names and ``DataRep keywords``)
+
+Completed
+---------
+
+-  Species (``organism``)
+
+   -  NCBITAXON_
+   -  license: UMLS [2]_
+   -  latest release: 2018-07-06
+   -  maintainer: NCBI (info@ncbi.nlm.nih.gov)
+
+-  Diagnosis (``disease_diagnosis``)
+
+   -  DOID_
+   -  License: `CC BY`_
+   -  latest release: 2018-03-02
+   -  maintainer: Lynn Schriml, U Maryland, MD, US
+      (lynn.schriml@gmail.com)
+   -  notes: Features ICD cross-reference
+
+-  Cell subset (``cell_subset``)
+
+   -  CellOntology_
+   -  license: `CC BY`_
+   -  latest release: 2018-07-11
+   -  maintainer: Alexander Diehl, Buffalo, NY, US
+      (addiehl@buffalo.edu)
+
+-  Tissue (``tissue``)
+
+   -  Uberon_
+   -  License: `CC BY`_
+   -  latest release: 2018-10-15
+   -  Maintainer: Chris Mungall, LBL, CA, US
+      (cjmungall@lbl.gov)
+
+Under evaluation
+----------------
+
+-  Strain name (``strain_name``)
+
+   -  Suggested ontologies:
+
+      -  JAX
+      -  IEDB
+
+   -  Issues:
+   
+      -  Nomenclature
+      -  one ontology is not enough	
+
+
+Technical aspects
+=================
+
+-  Repositories:
+
+   -  UID assigned by ontologies are guaranteed to be unique and 
+      permanent [3]_.
+   -  A repository MAY use internal identifiers that are distinct from
+      UIDs. However, to be AIRR-compliant it MUST be able to map UIDs to
+      its identifiers.
+   -  Points of “AIRR compliance” would typically be:
+
+      -  When data is extracted from the repository through a Query API
+         (CRWG)
+      -  When data is extracted from the repository into a file format
+         (DataRep)
+
+-  Integration of ontologies into repositories:
+
+   -  There are two main ontology providers offering a REST API and all
+      the ontologies listed above:
+
+      -  NCBO Bioportal [https://bioportal.bioontology.org]
+      -  OLS ontology [https://www.ebi.ac.uk/ols/ontologies]
+
+   -  NCBO can apparently be slow and sometimes not that stable, while
+      OLS seems to be more stable and potentially has a better long-term
+      support.
+   -  Remote ontology services tend to be slow and create external
+      dependencies. On the other hand, while local hosting of an
+      ontology is possible (and partially supported by NCBO and OLS), it
+      requires non-negligible resources. The Team's current assumption
+      is that queries to remote ontology services can be substantially
+      accelerated if only the relevant section of a respective ontology
+      is queried. Therefore a local service would not be necessary.
+   -  Repositories should store both the IDs and the values in their
+      database. This way, they do not have to query the ontology in a
+      scenario where human-readable output is required. In the case of
+      changes, most ontologies try to follow the practice of not
+      changing a term value but instead create a new term with the new
+      value and a new ID, and deprecating the old term. Therefore term
+      deprecation needs to be handled by the repository.
+   -  Like for the databases, also the API should be able to handle both
+      IDs and values as query input and return both during a query.
+   -  The user interface (UI) should offer an ontology-backed
+      autocomplete. NCBO provides some JavaScript code to use. The UI
+      must not offer deprecated terms. To allow entry of terms not
+      present in the ontology, data can be prefixed with some text that
+      will allow the data validation to proceed (e.g., if an entry
+      starts with "other -" the UI will not autocomplete/validate).
+      Later, i.e. when the term has been created, the data will be
+      updated.
+
+-  Note that the complete IEDB can be `downloaded as SQL dump`__, it is
+   licensed under `CC BY`_. At a first glance, the main overlap seems to
+   be with ``organism``, ``strain_name`` and to a smaller extent
+   ``disease_diagnosis``. However, sample information like ``cell_subset``
+   and ``tissue`` seems to be largely absent from IEDB, so it could
+   currently not be the one-stop solution for AIRR.
+
+__ https://www.iedb.org/database_export_v3.php
+
+
+Footnotes
+=========
+
+.. [1] See the "Glossary" section on how to interpret term written in
+   all-caps.
+.. [2] Will require further review the `UMLS Metathesaurus License
+   <https://uts.nlm.nih.gov/license.html>`_ is not a free license,
+   however it needs to be clarified how much of it relates to the work
+   (i.e. the taxonomy itself) and how much to the service.
+.. [3] This has more recently (early 2020) been called in question and
+   will be revisited during the next sprint. Note that the uncertainty
+   revolves around the question what exactly constitues a UID, rather
+   than the question whether a UID is permanent and unique.
+   
+Appendix
+========
+   
+Glossary
+--------
+
+-  MUST / REQUIRED: Indicates that an element or action is necessary to
+   conform to the standard.
+
+-  SHOULD / RECOMMENDED: Indicates that an element or action is
+   considered to be best practice by AIRR, but not necessary to conform
+   to the standard.
+
+-  MAY / OPTIONAL: Indicates that it is at the discretion of the user
+   to use an element or perform an action.
+
+-  MUST NOT / FORBIDDEN: Indicates that an element or action will be in
+   conflict with the standard.
+
+.. Links
+
+.. _CC0: https://creativecommons.org/publicdomain/zero/1.0/
+.. _`CC BY`: https://creativecommons.org/licenses/by/4.0/
+.. _NCBITAXON: https://bioportal.bioontology.org/ontologies/NCBITAXON
+.. _DOID: https://bioportal.bioontology.org/ontologies/DOID
+.. _CellOntology: https://bioportal.bioontology.org/ontologies/CL
+.. _Uberon: https://bioportal.bioontology.org/ontologies/UBERON
+

--- a/docs/standards/overview.rst
+++ b/docs/standards/overview.rst
@@ -15,3 +15,4 @@ Information about all of the AIRR Community standards.
    Software Guidelines <../swtools/airr_swtools_standard>
    AIRR Data Commons API <../api/adc_api>
    Schema Release Notes <news>
+   Ontologies and Vocabularies <../ontovoc/introduction_ontovoc>

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -479,7 +479,7 @@ Diagnosis:
                 name: Diagnosis
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: Human Disease Ontology
                     url: https://www.ebi.ac.uk/ols/ontologies/DOID
                     top_node:
@@ -596,7 +596,7 @@ Sample:
                 name: Tissue
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: UBERON
                     url: https://www.ebi.ac.uk/ols/ontologies/uberon
                     top_node:
@@ -690,7 +690,7 @@ CellProcessing:
                 name: Cell subset
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: CL
                     url: https://www.ebi.ac.uk/ols/ontologies/cl
                     top_node:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -479,7 +479,7 @@ Diagnosis:
                 name: Diagnosis
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: Human Disease Ontology
                     url: https://www.ebi.ac.uk/ols/ontologies/DOID
                     top_node:
@@ -596,7 +596,7 @@ Sample:
                 name: Tissue
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: UBERON
                     url: https://www.ebi.ac.uk/ols/ontologies/uberon
                     top_node:
@@ -690,7 +690,7 @@ CellProcessing:
                 name: Cell subset
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: CL
                     url: https://www.ebi.ac.uk/ols/ontologies/cl
                     top_node:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -479,7 +479,7 @@ Diagnosis:
                 name: Diagnosis
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: Human Disease Ontology
                     url: https://www.ebi.ac.uk/ols/ontologies/DOID
                     top_node:
@@ -596,7 +596,7 @@ Sample:
                 name: Tissue
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: UBERON
                     url: https://www.ebi.ac.uk/ols/ontologies/uberon
                     top_node:
@@ -690,7 +690,7 @@ CellProcessing:
                 name: Cell subset
                 format: ontology
                 ontology:
-                    draft: true
+                    draft: false
                     name: CL
                     url: https://www.ebi.ac.uk/ols/ontologies/cl
                     top_node:


### PR DESCRIPTION
Currently the OntoVoc reports are only available as GDocs, but they should be part of the official AIRR documentation.

Add the report of the November 2018 sprint to the docs.