### PR TITLE
Add reporting of Dual-D segments to NCBI specs

### DIFF
--- a/docs/miairr/specification_miairr_ncbi.rst
+++ b/docs/miairr/specification_miairr_ncbi.rst
@@ -270,7 +270,9 @@ study:
 
 -  REQUIRED: key ``D_segment``, both coordinates MUST be within
    ``V_region``. This key is only REQUIRED for sequences of applicable
-   loci (*IGH*, *TRB*, *TRD* [8]_).
+   loci (*IGH*, *TRB*, *TRD* [8]_). In the rare case of rearrangements
+   using two D segments, this key SHOULD occur twice, but the
+   coordinates of both keys MUST NOT overlap.
 
 -  REQUIRED: key ``J_segment``, both coordinates MUST be within
    ``V_region``.


### PR DESCRIPTION
With the addition of a set of `d2*` keys in the `Rearrangement` object, to allow for annotation of rearrangements utilizing two D segment, we need to represent this information also in the MiAIRR-to-NCBI specification.

* Add annotation guideline for Dual-D rearrangements to NCBI spec