### PR TITLE
Added x-airr keywords for primary_annotation

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1193,6 +1193,10 @@ DataProcessing:
                 If true, indicates this is the primary or default data processing for
                 the repertoire and its rearrangments. If false, indicates this is a secondary
                 or additional data processing.
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
         software_versions:
             type: string
             description: Version number and / or date, include company pipelines
@@ -1287,6 +1291,10 @@ DataProcessing:
         analysis_provenance_id:
             type: string
             description: Identifier for machine-readable PROV model of analysis provenance
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
 
 SampleProcessing:
     discriminator: AIRR

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1193,6 +1193,10 @@ DataProcessing:
                 If true, indicates this is the primary or default data processing for
                 the repertoire and its rearrangments. If false, indicates this is a secondary
                 or additional data processing.
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
         software_versions:
             type: string
             description: Version number and / or date, include company pipelines
@@ -1287,6 +1291,10 @@ DataProcessing:
         analysis_provenance_id:
             type: string
             description: Identifier for machine-readable PROV model of analysis provenance
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
 
 SampleProcessing:
     discriminator: AIRR

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1193,6 +1193,10 @@ DataProcessing:
                 If true, indicates this is the primary or default data processing for
                 the repertoire and its rearrangments. If false, indicates this is a secondary
                 or additional data processing.
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
         software_versions:
             type: string
             description: Version number and / or date, include company pipelines

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1291,6 +1291,10 @@ DataProcessing:
         analysis_provenance_id:
             type: string
             description: Identifier for machine-readable PROV model of analysis provenance
+            x-airr:
+                miairr: false
+                required: true
+                nullable: true
 
 SampleProcessing:
     discriminator: AIRR


### PR DESCRIPTION
Assume this should be the same as data_processing_id