### PR TITLE
Fix bug in logtable generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -355,12 +355,12 @@ for key, v in airr_schema.items():
                     if "subset" in airr_properties[airr_property]["x-airr"]:
                         airr_subset = airr_properties[airr_property]["x-airr"]["subset"]
                     else:
-                        airr_set = ""
+                        airr_subset = ""
 
                     if "name" in airr_properties[airr_property]["x-airr"]:
                         airr_name = airr_properties[airr_property]["x-airr"]["name"]
                     else:
-                        airr_name =""
+                        airr_name = ""
 
                     if "format" in airr_properties[airr_property]["x-airr"]:
                         airr_format = airr_properties[airr_property]["x-airr"]["format"].capitalize()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -344,15 +344,23 @@ for key, v in airr_schema.items():
 
                     if "description" in str(property_values):
                         airr_description = airr_properties[airr_property]["description"]
+                    else:
+                        airr_description = ""
 
-                    if "set" in str(property_values):
+                    if "'set'" in str(property_values):
                         airr_set = airr_properties[airr_property]["x-airr"]["set"]
+                    else:
+                        airr_set = ""
 
                     if "subset" in airr_properties[airr_property]["x-airr"]:
                         airr_subset = airr_properties[airr_property]["x-airr"]["subset"]
+                    else:
+                        airr_set = ""
 
                     if "name" in airr_properties[airr_property]["x-airr"]:
                         airr_name = airr_properties[airr_property]["x-airr"]["name"]
+                    else:
+                        airr_name =""
 
                     if "format" in airr_properties[airr_property]["x-airr"]:
                         airr_format = airr_properties[airr_property]["x-airr"]["format"].capitalize()


### PR DESCRIPTION
Adds a handling routine for fields with empty strings. It does not change the current rendered table but potentially avoids overwriting not defined fields.   
