### PR TITLE
MiAIRR_Elements.tsv adjustments

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -320,6 +320,16 @@ data_elements = [["Set",
                   "Example",
                   "Requirement"]]
 
+
+# func to chop down long strings of the table
+def wrap_col(string, str_length=11):
+    if [x for x in string.split(" ") if len(x) > 25]:
+        parts = [string[i:i + str_length].strip() for i in range(0, len(string), str_length)]
+        return ('\n'.join(parts) + '\n')
+    else:
+        return (string)
+
+
 # iterate over first level of yaml items
 for key, v in airr_schema.items():
     # iterate over second level of yaml items
@@ -362,14 +372,12 @@ for key, v in airr_schema.items():
 
                         if "ontology" in airr_properties[airr_property]["x-airr"]:
 
-                            airr_format = "Ontology: { name: " + str(
-                                airr_properties[airr_property]["x-airr"]["ontology"]["name"])
-                            airr_format += ", top_node: {"
-                            airr_format += "id: " + str(airr_properties[airr_property]["x-airr"]["ontology"]["top_node"]["id"])
-                            airr_format += ", value: " + str(airr_properties[airr_property]["x-airr"]["ontology"]["top_node"]["value"]) + "}"
-                            airr_format += ", draft: " + str(airr_properties[airr_property]["x-airr"]["ontology"]["draft"])
-                            airr_format += ", url: " + str(airr_properties[airr_property]["x-airr"]["ontology"]["url"])
-                            airr_format += " }"
+                            base_dic = airr_properties[airr_property]["x-airr"]["ontology"]
+                            ontology_format = (str(base_dic["name"]), str(base_dic["url"]),
+                            str(base_dic["top_node"]["id"]),str(base_dic["top_node"]["value"]), str(base_dic["draft"]))
+                            # replace name with url-linked name
+                            airr_format = "Ontology: { name: `%s <%s/>`_ , top_node: { id: %s, value: %s}, draft: %s}"%(
+                                ontology_format)
                             # get 'type' for ontology
                             airr_data_type = airr_schema["Ontology"]["properties"]["value"]["type"]
                             airr_field_value_example = "id: " + str(airr_properties[airr_property]["example"]["id"]) + ", value: " + str(airr_properties[airr_property]["example"]["value"])
@@ -390,6 +398,9 @@ for key, v in airr_schema.items():
                             airr_format = "Any positive number"
                         elif airr_data_type == "boolean":  #
                             airr_format = "T | F"
+
+                    # airr_property = wrap_col(airr_property)
+                    airr_field_value_example = wrap_col(str(airr_field_value_example))
 
                     r = [airr_set, airr_subset, airr_name, airr_property,
                          airr_data_type, airr_format, airr_description,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,8 +317,8 @@ data_elements = [["Set",
                   "Type",
                   "Format",
                   "Definition",
-                  "Example"]]
-
+                  "Example",
+                  "MiAIRR Requirement Levels"]]
 
 # iterate over first level of yaml items
 for key, v in airr_schema.items():
@@ -328,46 +328,42 @@ for key, v in airr_schema.items():
         airr_properties = airr_schema[key][k]
         if "properties" in k:
             for airr_property, property_values in airr_properties.items():
-                # get only miairr properties
-                if "miairr" in str(property_values) and airr_properties[airr_property]["x-airr"]["miairr"] is True:
 
-                    if "deprecated" in str(property_values): # currently none is deprecated
-                        continue
+                # get only not deprecated miairr properties (assuming no `deprecated=False`)
+                if "x-airr" in str(property_values) and not "deprecated" in airr_properties[
+                    airr_property]["x-airr"] and "miairr" in airr_properties[
+                    airr_property]["x-airr"]:
+
+                    airr_name = airr_properties[airr_property]["x-airr"]["name"]
+                    miairr_required = airr_properties[airr_property]["x-airr"]["miairr"]
 
                     if "'type'" in str(property_values):  # get 'type' for all properties except ontology
                         airr_data_type = airr_properties[airr_property]["type"]
-
-                    if "example" in str(property_values):
+                    else:
+                        airr_data_type = ""
+                    if "'example'" in str(property_values):
                         airr_field_value_example = airr_properties[airr_property]["example"]
                     else:
                         airr_field_value_example = ""
-
-                    if "description" in str(property_values):
+                    if "'description'" in str(property_values):
                         airr_description = airr_properties[airr_property]["description"]
                     else:
                         airr_description = ""
-
                     if "'set'" in str(property_values):
                         airr_set = airr_properties[airr_property]["x-airr"]["set"]
                     else:
                         airr_set = ""
-
                     if "subset" in airr_properties[airr_property]["x-airr"]:
                         airr_subset = airr_properties[airr_property]["x-airr"]["subset"]
                     else:
                         airr_subset = ""
-
-                    if "name" in airr_properties[airr_property]["x-airr"]:
-                        airr_name = airr_properties[airr_property]["x-airr"]["name"]
-                    else:
-                        airr_name = ""
-
                     if "format" in airr_properties[airr_property]["x-airr"]:
                         airr_format = airr_properties[airr_property]["x-airr"]["format"].capitalize()
 
                         if "ontology" in airr_properties[airr_property]["x-airr"]:
 
-                            airr_format = "Ontology: { name: " + str(airr_properties[airr_property]["x-airr"]["ontology"]["name"])
+                            airr_format = "Ontology: { name: " + str(
+                                airr_properties[airr_property]["x-airr"]["ontology"]["name"])
                             airr_format += ", top_node: {"
                             airr_format += "id: " + str(airr_properties[airr_property]["x-airr"]["ontology"]["top_node"]["id"])
                             airr_format += ", value: " + str(airr_properties[airr_property]["x-airr"]["ontology"]["top_node"]["value"]) + "}"
@@ -380,26 +376,25 @@ for key, v in airr_schema.items():
 
                         elif "controlled vocabulary" in str(property_values):
                             if airr_properties[airr_property].get("enum") is not None:
-                                airr_format = "Controlled vocabulary: " +  str(airr_properties[airr_property]["enum"])
+                                airr_format = "Controlled vocabulary: " + str(airr_properties[airr_property]["enum"])
                             elif airr_properties[airr_property].get("items") is not None:
-                                airr_format = "Controlled vocabulary: " +  str(airr_properties[airr_property]["items"]["enum"])
+                                airr_format = "Controlled vocabulary: " + str(airr_properties[airr_property]["items"]["enum"])
 
                     elif "format" not in airr_properties[airr_property]["x-airr"]:
 
                         if airr_data_type == "string":
                             airr_format = "Free text"
-                        elif airr_data_type == "integer": #
+                        elif airr_data_type == "integer":  #
                             airr_format = "Any positive integer"
-                        elif airr_data_type == "number": #
+                        elif airr_data_type == "number":  #
                             airr_format = "Any positive number"
                         elif airr_data_type == "boolean":  #
                             airr_format = "T | F"
 
                     r = [airr_set, airr_subset, airr_name, airr_property,
                          airr_data_type, airr_format, airr_description,
-                         airr_field_value_example]
+                         airr_field_value_example, miairr_required]
                     data_elements.append(r)
-
 
 with open(os.path.join(dl_path, '%s.tsv' % "AIRR_Minimal_Standard_Data_Elements"), "w") as f:
     writer = csv.writer(f, dialect='excel-tab')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -318,7 +318,7 @@ data_elements = [["Set",
                   "Format",
                   "Definition",
                   "Example",
-                  "MiAIRR Requirement Levels"]]
+                  "Requirement"]]
 
 # iterate over first level of yaml items
 for key, v in airr_schema.items():

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -332,6 +332,9 @@ def wrap_col(string, str_length=11):
 
 # iterate over first level of yaml items
 for key, v in airr_schema.items():
+    # skip Cell object until #369 is fixed, then remove next two lines
+    if key == "Cell" :
+        continue
     # iterate over second level of yaml items
     for k, v in airr_schema[key].items():
         # get properties

--- a/docs/miairr/data_elements.rst
+++ b/docs/miairr/data_elements.rst
@@ -18,4 +18,4 @@ of sequence data, and processed AIRR sequences.
    :header-rows: 1
    :stub-columns: 0
    :align: left
-   :widths: 5,10,10,10,10,10,30,15
+   :widths: 5,10,10,10,10,10,25,10,10

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -14,25 +14,44 @@ Under development (Version 1.3.0)
 **Current changes in the development branch.**
 
 + Added EBI OLS as default source for ``ontologies``
- .. #296 by bussec was merged on Jan 4, 2020
+
+.. #296 by bussec was merged on Jan 4, 2020
+
 + Expanded description for ``pcr_target``
- .. #288 by bussec was merged on Dec 10, 2019
+
+.. #288 by bussec was merged on Dec 10, 2019
+
 + Fix capitalization of ``age_unit`` description
- .. #290 by bcorrie was merged on Dec 10, 2019
+
+.. #290 by bcorrie was merged on Dec 10, 2019
+
 + Fix name of ``age`` fields
- .. #285 by bcorrie was merged on Nov 27, 2019
+
+.. #285 by bcorrie was merged on Nov 27, 2019
+
 + Introduced ``cell_species``
- .. #260 by bussec was merged on Nov 8, 2019; #281 Reverted ``locus_species``  by bcorrie was merged on Nov 27, 2019
+
+.. #260 by bussec was merged on Nov 8, 2019; #281 Reverted ``locus_species``  by bcorrie was merged on Nov 27, 2019
+
 + Added ``sample_processing_id``
- .. #263 by schristley was merged on Oct 21
+
+.. #263 by schristley was merged on Oct 21
+
 + Added vocabularies/ontologies as JSON string for: Cell subset, Target substrate, Library generation method, Complete sequences, Physical linkage of different loci
- .. #155 by bussec was merged on Oct 16, 2018 • Approved
+
+.. #155 by bussec was merged on Oct 16, 2018 • Approved
+
 + Include format JSON string
- .. #155 by bussec was merged on Oct 16, 2018 • Approved
+
+.. #155 by bussec was merged on Oct 16, 2018 • Approved
+
 + Introduced age ranges, ``age_min``, ``age_max``, and ``age_unit``
- .. #254 by franasa was merged on Oct 11 • Approved
+
+.. #254 by franasa was merged on Oct 11 • Approved
+
 + Updated schema with more concise VDJ call descriptions
- .. #257 by bcorrie was merged on Oct 7 • Approved
+
+.. #257 by bcorrie was merged on Oct 7 • Approved
 
 Version 1.2.1: Oct 5, 2018
 --------------------------------------------------------------------------------
@@ -40,11 +59,16 @@ Version 1.2.1: Oct 5, 2018
 **Minor patch release.**
 
 + Schema gene vs segment terminology corrections
- .. #153 by javh was merged on Sep 13 • Approved
+
+.. #153 by javh was merged on Sep 13 • Approved
+
 + Added ``Info`` object
- .. #150 by schristley was merged on Aug 28
+
+.. #150 by schristley was merged on Aug 28
+
 + Updated ``cell_subset`` URL in AIRR schema
- .. #221 by bussec was merged on Aug 7
+
+.. #221 by bussec was merged on Aug 7
 
 Version 1.2.0: Aug 18, 2018
 --------------------------------------------------------------------------------
@@ -54,10 +78,14 @@ Version 1.2.0: Aug 18, 2018
 + Definition change for the coordinate fields of the Rearrangement and Alignment schema.
   Coordinates are now defined as 1-based closed intervals, instead of 0-based half-open
   intervals (as previously defined in v1.1 of the schema).
+
 + Removed foreign ``study_id`` fields
- .. #134 by schristley was merged on Jul 12
+
+.. #134 by schristley was merged on Jul 12
+
 + Introduced ``keywords_study`` field
- .. #200 by bussec was merged on Jun 13 • Approved
+
+.. #200 by bussec was merged on Jun 13 • Approved
 
 Version 1.1.0: May 3, 2018
 --------------------------------------------------------------------------------
@@ -65,53 +93,98 @@ Version 1.1.0: May 3, 2018
 **Initial public released of the Rearrangement and Alignment schemas.**
 
 + Added ``required`` and ``nullable`` constrains to AIRR schema.
- .. #182 by bussec was merged on Apr 1 • Approved
+
+.. #182 by bussec was merged on Apr 1 • Approved
+
 + Schema definitions for MiAIRR attributes and ontology.
- .. #182 by bussec was merged on Apr 1 • Approved
+
+.. #182 by bussec was merged on Apr 1 • Approved
+
 + Introduction of an ``x-airr`` object indicating if field is required by MiAIRR
- .. #182 by bussec was merged on Apr 1 • Approved
+
+.. #182 by bussec was merged on Apr 1 • Approved
+
 + Rename ``rearrangement_set_id`` to ``data_processing_id``
- .. #182 by bussec was merged on Apr 1 • Approved
+
+.. #182 by bussec was merged on Apr 1 • Approved
+
 + Rename ``study_description`` to ``study_type``
- .. #182 by bussec was merged on Apr 1 • Approved
+
+.. #182 by bussec was merged on Apr 1 • Approved
+
 + Added ``physical_quantity`` format
- .. #182 by bussec was merged on Apr 1 • Approved
+
+.. #182 by bussec was merged on Apr 1 • Approved
+
 + Raw sequencing files into separate schema object
- .. #182 by bussec was merged on Apr 1 • Approved
+
+.. #182 by bussec was merged on Apr 1 • Approved
+
 + Rename Attributes object
- .. #182 by bussec was merged on Apr 1 • Approved
+
+.. #182 by bussec was merged on Apr 1 • Approved
+
 + Added ``primary_annotation`` and ``repertoire_id``
- .. #156 by schristley was merged on Mar 4 • Approved
+
+.. #156 by schristley was merged on Mar 4 • Approved
+
 + Added ``diagnosis`` to repertoire object
- .. #156 by schristley was merged on Mar 4 • Approved
+
+.. #156 by schristley was merged on Mar 4 • Approved
+
 + Added ontology for ``organism``
- .. #156 by schristley was merged on Mar 4 • Approved
+
+.. #156 by schristley was merged on Mar 4 • Approved
+
 + Added more detailed specification of ``sequencing_run``, ``repertoire`` and ``rearrangement``
- .. #156 by schristley was merged on Mar 4 • Approved
+
+.. #156 by schristley was merged on Mar 4 • Approved
+
 + Added repertoire schema
- .. #156 by schristley was merged on Mar 4 • Approved
+
+.. #156 by schristley was merged on Mar 4 • Approved
+
 + Rename ``definitions.yaml`` to ``airr-schema.yaml``
- .. #66. in progress .. #124 by javh was merged on Apr 20
+
+.. #66. in progress.. #124 by javh was merged on Apr 20
+
 + Removed ``c_call``, ``c_score`` and ``c_cigar`` from required as this is not
   typical reference aligner output
- .. #106 by javh was merged on Apr 18, 2018
+
+.. #106 by javh was merged on Apr 18, 2018
+
 + Renamed ``vdj_score``, ``vdj_identity``, ``vdj_evalue``, and ``vdj_cigar`` to ``score``,
   ``identity``, ``evalue``, and ``cigar``
- .. #106 by javh was merged on Apr 18, 2018
+
+.. #106 by javh was merged on Apr 18, 2018
+
 + Added missing ``c_identity`` and ``c_evalue`` fields to ``Rearrangement`` spec
- .. #94 on Mar 22, 2018
+
+.. #94 on Mar 22, 2018
+
 + Swapped order of `N` and `S` operators in CIGAR string
- .. #94 on Mar 22, 2018
+
+.. #94 on Mar 22, 2018
+
 + Some description clean up for consistency in ``Rearrangement`` spec
- .. #94 on Mar 22, 2018
+
+.. #94 on Mar 22, 2018
+
 + Remove repeated objects in ``definitions.yaml``
- .. #78 on Jan 26, 2018 #53
+
+.. #78 on Jan 26, 2018 #53
+
 + Added ``Alignment`` object to ``definitions.yaml``
- .. #78 on Jan 26, 2018 #67
+
+.. #78 on Jan 26, 2018 #67
+
 + Updated MiARR format consistency check TSV with junction change
- .. #75 on Jan 9, 2018. also: #84, #85, #89
+
+.. #75 on Jan 9, 2018. also: #84, #85, #89
+
 + Changed definition from functional to productive
- .. #75 on Jan 9, 2018. also: #84,. #85,. #89
+
+.. #75 on Jan 9, 2018. also: #84,. #85,. #89
 
 Version 1.0.1: Jan 9, 2018
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Following the recent changes from #319, I have reviewed and adjusted the `conf.py` file to generate the `AIRR_Minimal_Standard_Data_Elements.tsv`.

As pointed in #359 species name is still organism in 1.3 but should be reviewed for 2.0

I haven't made any changes to the `data_elements.rst`  but after the changes made on the `conf.py ` the table is generated and stored in `_download` but it does not get rendered, @javh maybe you have an idea why is this?