### PR TITLE
DataProcessing as a top-level object and independent of Repertoire

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1641,10 +1641,8 @@ Repertoire:
                 nullable: false
                 adc-query-support: true
         data_processing:
-            type: array
-            description: List of Data Processing objects
-            items:
-                $ref: '#/DataProcessing'
+            $ref: '#/DataProcessing'
+            description: Data Processing object
             x-airr:
                 nullable: false
                 adc-query-support: true

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1641,10 +1641,8 @@ Repertoire:
                 nullable: false
                 adc-query-support: true
         data_processing:
-            type: array
-            description: List of Data Processing objects
-            items:
-                $ref: '#/DataProcessing'
+            $ref: '#/DataProcessing'
+            description: Data Processing object
             x-airr:
                 nullable: false
                 adc-query-support: true

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1641,10 +1641,8 @@ Repertoire:
                 nullable: false
                 adc-query-support: true
         data_processing:
-            type: array
-            description: List of Data Processing objects
-            items:
-                $ref: '#/DataProcessing'
+            $ref: '#/DataProcessing'
+            description: Data Processing object
             x-airr:
                 nullable: false
                 adc-query-support: true


### PR DESCRIPTION
TODO: need to incorporate design decisions from the `DataProcessing` sprint.

--- this is old ---

Allowing only a single `DataProcessing` object for a `Repertoire` object implies:

- If the same set of sequencing files are data processed in multiple ways, e.g. MiXCR for one workflow and IgBlast for another, those require separate `Repertoire` objects with their own id.

- That single `DataProcessing` is implicitly the primary annotation, so there is no need for the `primary_annnotation` flag.

- Both `repertoire_id` and `data_processing_id` are not needed together to select the appropriate set of rearrangements for a Repertoire, now `repertoire_id` is sufficient. Thus, `data_processing_id` can be removed from `Rearrangement` unless it's needed there for another purpose.

- This makes the `Repertoire` concept more solid as being the annotated rearrangements for a biological repertoire for a single subject. A more abstract object, like `RepertoireSet` #445 , is needed to support flexible analysis.

This doesn't address other issues regarding the `DataProcessing` object.
