### PR TITLE
Add v_frameshift, j_frameshift and d_frame fields.

### DIFF
--- a/docs/datarep/rearrangements.rst
+++ b/docs/datarep/rearrangements.rst
@@ -244,8 +244,20 @@ Alignments
 There is no required alignment scheme for the nucleotide and amino acid alignment
 fields. These fields may, or may not, include numbering spacers (e.g., IMGT-numbering gaps),
 variations in case to denote mismatches, deletions, or other features appropriate to the tool that
-performed the alignment. The only strict requirement is that the query ("sequence") and
-reference ("germline") **must** be properly aligned.
+performed the alignment. The only strict requirement is that the query (``sequence``) and
+reference (``germline``) **must** be properly aligned.
+
+Frameshifts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For purposes of annotating alignments, a frameshift is defined as a frameshift that is
+maintained until the end of the aligned gene, where frames are designated numerically as
+1 (in-frame), 2, or 3. For example, an V gene alignment that starts in
+frame 1 and ends in frame 2, disrupting the conserved cystine, would be defined as a frameshift.
+Whereas, a V gene alignment with an internal frameshift that corrects with a second frameshift,
+back to the original frame 1 prior to the conserved cystine, would not need to be annotated
+as a frameshift.
+
 
 Fields
 ------------------------------

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -3,6 +3,18 @@
 Schema Release Notes
 ================================================================================
 
+Version 1.4.0: (In development)
+--------------------------------------------------------------------------------
+
+**Version 1.4, In development.**
+
+Rearrangement Schema:
+
+1. Added the optional fields ``v_frameshift``, ``j_frameshift``,
+   ``d_frame`` and ``d2_frame`` defining annotations related to alignment
+   reading frames.
+
+
 Version 1.3.1: October 13, 2020
 --------------------------------------------------------------------------------
 

--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -3,10 +3,10 @@
 Schema Release Notes
 ================================================================================
 
-Version 1.4.0: (In development)
+Version 1.4.0-dev: (In development)
 --------------------------------------------------------------------------------
 
-**Version 1.4, In development.**
+**Version 1.4-dev, In development.**
 
 Rearrangement Schema:
 

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -2597,6 +2597,26 @@ Rearrangement:
         p5j_length:
             type: integer
             description: Number of palindromic nucleotides 5' of the J gene alignment.
+        v_frameshift:
+            type: boolean
+            description: >
+                True if the V gene in the query nucleotide sequence contains a translational
+                frameshift relative to the frame of the V gene reference sequence.
+        j_frameshift:
+            type: boolean
+            description: >
+                True if the J gene in the query nucleotide sequence contains a translational
+                frameshift relative to the frame of the J gene reference sequence.
+        d_frame:
+            type: integer
+            description: >
+                Numerical reading frame (1, 2, 3) of the first or only D gene in the query nucleotide sequence,
+                where frame 1 is relative to the first codon of D gene reference sequence.
+        d2_frame:
+            type: integer
+            description: >
+                Numerical reading frame (1, 2, 3) of the second D gene in the query nucleotide sequence,
+                where frame 1 is relative to the first codon of D gene reference sequence.
         consensus_count:
             type: integer
             description: >

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -2597,6 +2597,26 @@ Rearrangement:
         p5j_length:
             type: integer
             description: Number of palindromic nucleotides 5' of the J gene alignment.
+        v_frameshift:
+            type: boolean
+            description: >
+                True if the V gene in the query nucleotide sequence contains a translational
+                frameshift relative to the frame of the V gene reference sequence.
+        j_frameshift:
+            type: boolean
+            description: >
+                True if the J gene in the query nucleotide sequence contains a translational
+                frameshift relative to the frame of the J gene reference sequence.
+        d_frame:
+            type: integer
+            description: >
+                Numerical reading frame (1, 2, 3) of the first or only D gene in the query nucleotide sequence,
+                where frame 1 is relative to the first codon of D gene reference sequence.
+        d2_frame:
+            type: integer
+            description: >
+                Numerical reading frame (1, 2, 3) of the second D gene in the query nucleotide sequence,
+                where frame 1 is relative to the first codon of D gene reference sequence.
         consensus_count:
             type: integer
             description: >

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -2754,6 +2754,30 @@ Rearrangement:
             type: integer
             nullable: true
             description: Number of palindromic nucleotides 5' of the J gene alignment.
+        v_frameshift:
+            type: boolean
+            nullable: true
+            description: >
+                True if the V gene in the query nucleotide sequence contains a translational
+                frameshift relative to the frame of the V gene reference sequence.
+        j_frameshift:
+            type: boolean
+            nullable: true
+            description: >
+                True if the J gene in the query nucleotide sequence contains a translational
+                frameshift relative to the frame of the J gene reference sequence.
+        d_frame:
+            type: integer
+            nullable: true
+            description: >
+                Numerical reading frame (1, 2, 3) of the first or only D gene in the query nucleotide sequence,
+                where frame 1 is relative to the first codon of D gene reference sequence.
+        d2_frame:
+            type: integer
+            nullable: true
+            description: >
+                Numerical reading frame (1, 2, 3) of the second D gene in the query nucleotide sequence,
+                where frame 1 is relative to the first codon of D gene reference sequence.
         consensus_count:
             type: integer
             nullable: true

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2381,6 +2381,21 @@ Rearrangement:
         p5j_length:
             type: integer
             description: Number of palindromic nucleotides 5' of the J gene alignment.
+        v_frameshift:
+            type: boolean
+            description: >
+                True if the V gene in the query nucleotide sequence contains a translational
+                frameshift relative to the frame of the V gene reference sequence.
+        j_frameshift:
+            type: boolean
+            description: >
+                True if the J gene in the query nucleotide sequence contains a translational
+                frameshift relative to the frame of the J gene reference sequence.
+        d_frame:
+            type: integer
+            description: >
+                Numerical reading frame (1, 2, 3) of the D gene in the query nucleotide sequence,
+                where frame 1 is relative to the first codon of D gene reference sequence.
         consensus_count:
             type: integer
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2394,7 +2394,12 @@ Rearrangement:
         d_frame:
             type: integer
             description: >
-                Numerical reading frame (1, 2, 3) of the D gene in the query nucleotide sequence,
+                Numerical reading frame (1, 2, 3) of the first or only D gene in the query nucleotide sequence,
+                where frame 1 is relative to the first codon of D gene reference sequence.
+        d2_frame:
+            type: integer
+            description: >
+                Numerical reading frame (1, 2, 3) of the second D gene in the query nucleotide sequence,
                 where frame 1 is relative to the first codon of D gene reference sequence.
         consensus_count:
             type: integer


### PR DESCRIPTION
I received a request from @jianye00 (IgBLAST developer) to add a reversed field name for a boolean to specify whether the observed V segment contains an internal frameshift, due to indel mutations or alignment against a defective pseudogene. They plan to add this field to the IgBLAST V-(D)-J rearrangement summary table.

This differs from `vj_in_frame`, which considers whether the V and J are in the same frame, but not whether the query V segment is in frame with its germline reference sequence.

In the spirit of completeness, I also added a boolean for J frameshifts and a numerical field for the D reading frame. The additions are:

```
v_frameshift:
    type: boolean
    description: >
        True if the V gene in the query nucleotide sequence contains a translational
        frameshift relative to the frame of the V gene reference sequence.
j_frameshift:
    type: boolean
    description: >
        True if the J gene in the query nucleotide sequence contains a translational
        frameshift relative to the frame of the J gene reference sequence.
d_frame:
    type: integer
    description: >
        Numerical reading frame (1, 2, 3) of the first or only D gene in the query nucleotide sequence,
        where frame 1 is relative to the first codon of D gene reference sequence.
d2_frame:
    type: integer
    description: >
        Numerical reading frame (1, 2, 3) of the second D gene in the query nucleotide sequence,
        where frame 1 is relative to the first codon of D gene reference sequence.
```

Are there any concerns with adding these fields to v1.4 and/or problems with the definitions?