### PR TITLE
handle case when more extra data in a row

### DIFF
--- a/lang/python/airr/interface.py
+++ b/lang/python/airr/interface.py
@@ -243,6 +243,7 @@ def load_repertoire(filename, validate=False, debug=False):
 
     # validate if requested
     if validate:
+        valid = True
         reps = md['Repertoire']
         i = 0
         for r in reps:
@@ -253,6 +254,8 @@ def load_repertoire(filename, validate=False, debug=False):
                 if debug:
                     sys.stderr.write('%s has repertoire at array position %i with validation error: %s\n' % (filename, i, e))
             i = i + 1
+        if not valid:
+            raise ValidationError('Repertoire file %s has validation errors\n' % (filename))
 
     # we do not perform any additional processing
     return md

--- a/lang/python/airr/io.py
+++ b/lang/python/airr/io.py
@@ -91,6 +91,11 @@ class RearrangementReader:
             raise StopIteration
 
         for f in row:
+            # row entry with no header
+            if f is None:
+                if self.validate:
+                    raise ValidationError('row has extra data')
+
             # Convert types
             spec = self.schema.type(f)
             try:
@@ -104,7 +109,7 @@ class RearrangementReader:
                 raise ValidationError('field %s has %s' %(f, e))
 
             # Adjust coordinates
-            if f.endswith('_start') and self.base == 1:
+            if f and f.endswith('_start') and self.base == 1:
                 try:
                     row[f] = row[f] - 1
                 except TypeError:

--- a/lang/python/airr/io.py
+++ b/lang/python/airr/io.py
@@ -95,6 +95,8 @@ class RearrangementReader:
             if f is None:
                 if self.validate:
                     raise ValidationError('row has extra data')
+                else:
+                    raise ValueError('row has extra data')
 
             # Convert types
             spec = self.schema.type(f)

--- a/lang/python/airr/specs/blank.airr.yaml
+++ b/lang/python/airr/specs/blank.airr.yaml
@@ -55,7 +55,7 @@ Repertoire:
         sample_type: null
         tissue:
           id: null
-          value: null
+          label: null
         anatomic_site: null
         disease_state_sample: null
         collection_time_point_relative: null

--- a/lang/python/tests/data/extra_data.tsv
+++ b/lang/python/tests/data/extra_data.tsv
@@ -1,0 +1,2 @@
+sequence_id	sequence	rev_comp	productive	v_call	d_call	j_call	sequence_alignment	germline_alignment	junction	junction	junction_aa	v_cigar	d_cigar	j_cigar
+1	2	F	F	5	6	7	8	9	10	11	12	13	14	15	not_in_header	not_in

--- a/lang/python/tests/data/good_repertoire.airr.yaml
+++ b/lang/python/tests/data/good_repertoire.airr.yaml
@@ -9,7 +9,7 @@ Repertoire:
       study_title: "Homo sapiens B and T cell repertoire - MZ twins"
       study_type:
         id: null
-        value: null
+        label: null
       study_description: "The adaptive immune system's capability to protect the body requires a highly diverse lymphocyte antigen receptor repertoire. However, the influence of individual genetic and epigenetic differences on these repertoires is not typically measured. By leveraging the unique characteristics of B, CD4+ T, and CD8+ T lymphocyte subsets isolated from monozygotic twins, we have quantified the impact of heritable factors on both the V(D)J recombination process and thymic selection in the case of T cell receptors, and show that the repertoires of both naive and antigen experienced cells are subject to biases resulting from differences in recombination. We show that biases in V(D)J usage, as well as biased N/P additions, contribute to significant variation in the CDR3 region. Moreover, we show that the relative usage of V and J gene segments is chromosomally biased, with approximately 1.5 times as many rearrangements originating from a single chromosome. These data refine our understanding of the heritable mechanisms affecting the repertoire, and show that biases are evident on a chromosome-wide level."
       inclusion_exclusion_criteria: null
       lab_name: "Mark M. Davis"
@@ -26,13 +26,13 @@ Repertoire:
       synthetic: false
       species:
         id: "NCBITaxon_9606"
-        value: "Homo sapiens"
+        label: "Homo sapiens"
       sex: F
       age_min: 27
       age_max: 27
       age_unit:
         id: UO_0000036
-        value: year
+        label: year
       age_event: null
       ancestry_population: null
       ethnicity: null
@@ -44,7 +44,7 @@ Repertoire:
         - study_group_description: null
           disease_diagnosis:
             id: null
-            value: null
+            label: null
           disease_length: null
           disease_stage: null
           prior_therapies: null
@@ -58,15 +58,15 @@ Repertoire:
         sample_type: "peripheral venous puncture"
         tissue:
           id: "UBERON_0000178"
-          value: "blood"
+          label: "blood"
         tissue_processing: "Ficoll gradient"
         cell_subset:
           id: "CL_0000788"
-          value: "naive B cell"
+          label: "naive B cell"
         cell_phenotype: "expression of CD20 and the absence of CD27"
         cell_species:
           id: "NCBITaxon_9606"
-          value: "Homo sapiens"
+          label: "Homo sapiens"
         single_cell: false
         cell_isolation: FACS
         template_class: RNA
@@ -124,7 +124,7 @@ Repertoire:
       study_title: "Homo sapiens B and T cell repertoire - MZ twins"
       study_type:
         id: null
-        value: null
+        label: null
       study_description: "The adaptive immune system's capability to protect the body requires a highly diverse lymphocyte antigen receptor repertoire. However, the influence of individual genetic and epigenetic differences on these repertoires is not typically measured. By leveraging the unique characteristics of B, CD4+ T, and CD8+ T lymphocyte subsets isolated from monozygotic twins, we have quantified the impact of heritable factors on both the V(D)J recombination process and thymic selection in the case of T cell receptors, and show that the repertoires of both naive and antigen experienced cells are subject to biases resulting from differences in recombination. We show that biases in V(D)J usage, as well as biased N/P additions, contribute to significant variation in the CDR3 region. Moreover, we show that the relative usage of V and J gene segments is chromosomally biased, with approximately 1.5 times as many rearrangements originating from a single chromosome. These data refine our understanding of the heritable mechanisms affecting the repertoire, and show that biases are evident on a chromosome-wide level."
       inclusion_exclusion_criteria: null
       lab_name: "Mark M. Davis"
@@ -141,13 +141,13 @@ Repertoire:
       synthetic: false
       species:
         id: "NCBITaxon_9606"
-        value: "Homo sapiens"
+        label: "Homo sapiens"
       sex: F
       age_min: 27
       age_max: 27
       age_unit:
         id: UO_0000036
-        value: year
+        label: year
       age_event: null
       ancestry_population: null
       ethnicity: null
@@ -159,7 +159,7 @@ Repertoire:
         - study_group_description: null
           disease_diagnosis:
             id: null
-            value: null
+            label: null
           disease_length: null
           disease_stage: null
           prior_therapies: null
@@ -173,15 +173,15 @@ Repertoire:
         sample_type: "peripheral venous puncture"
         tissue:
           id: "UBERON_0000178"
-          value: "blood"
+          label: "blood"
         tissue_processing: "Ficoll gradient"
         cell_subset:
           id: "CL_0000787"
-          value: "memory B cell"
+          label: "memory B cell"
         cell_phenotype: "expression of CD20 and CD27"
         cell_species:
           id: "NCBITaxon_9606"
-          value: "Homo sapiens"
+          label: "Homo sapiens"
         single_cell: false
         cell_isolation: FACS
         template_class: RNA
@@ -239,7 +239,7 @@ Repertoire:
       study_title: "Homo sapiens B and T cell repertoire - MZ twins"
       study_type:
         id: null
-        value: null
+        label: null
       study_description: "The adaptive immune system's capability to protect the body requires a highly diverse lymphocyte antigen receptor repertoire. However, the influence of individual genetic and epigenetic differences on these repertoires is not typically measured. By leveraging the unique characteristics of B, CD4+ T, and CD8+ T lymphocyte subsets isolated from monozygotic twins, we have quantified the impact of heritable factors on both the V(D)J recombination process and thymic selection in the case of T cell receptors, and show that the repertoires of both naive and antigen experienced cells are subject to biases resulting from differences in recombination. We show that biases in V(D)J usage, as well as biased N/P additions, contribute to significant variation in the CDR3 region. Moreover, we show that the relative usage of V and J gene segments is chromosomally biased, with approximately 1.5 times as many rearrangements originating from a single chromosome. These data refine our understanding of the heritable mechanisms affecting the repertoire, and show that biases are evident on a chromosome-wide level."
       inclusion_exclusion_criteria: null
       lab_name: "Mark M. Davis"
@@ -256,13 +256,13 @@ Repertoire:
       synthetic: false
       species:
         id: "NCBITaxon_9606"
-        value: "Homo sapiens"
+        label: "Homo sapiens"
       sex: F
       age_min: 27
       age_max: 27
       age_unit:
         id: UO_0000036
-        value: year
+        label: year
       age_event: null
       ancestry_population: null
       ethnicity: null
@@ -274,7 +274,7 @@ Repertoire:
         - study_group_description: null
           disease_diagnosis:
             id: null
-            value: null
+            label: null
           disease_length: null
           disease_stage: null
           prior_therapies: null
@@ -288,15 +288,15 @@ Repertoire:
         sample_type: "peripheral venous puncture"
         tissue:
           id: "UBERON_0000178"
-          value: "blood"
+          label: "blood"
         tissue_processing: "Ficoll gradient"
         cell_subset:
           id: "CL_0000895"
-          value: "naive thymus-derived CD4-positive, alpha-beta T cell"
+          label: "naive thymus-derived CD4-positive, alpha-beta T cell"
         cell_phenotype: "expression of CD8 and absence of CD4 and CD45RO"
         cell_species:
           id: "NCBITaxon_9606"
-          value: "Homo sapiens"
+          label: "Homo sapiens"
         single_cell: false
         cell_isolation: FACS
         template_class: RNA

--- a/lang/python/tests/test_interface.py
+++ b/lang/python/tests/test_interface.py
@@ -8,6 +8,7 @@ import unittest
 
 # Load imports
 import airr
+from airr.schema import ValidationError
 
 # Paths
 test_path = os.path.dirname(os.path.realpath(__file__))
@@ -65,11 +66,11 @@ class TestInferface(unittest.TestCase):
 
         # Bad data
         try:
-
             result = airr.validate_rearrangement(self.data_bad)
             self.assertFalse(result, 'validate(): bad data failed')
-        except:
-            pass
+        except Exception as inst:
+            print(type(inst))
+            raise inst
 
     # @unittest.skip('-> load_repertoire(): skipped\n')
     def test_load_repertoire(self):
@@ -81,10 +82,13 @@ class TestInferface(unittest.TestCase):
 
         # Bad data
         try:
-            data = airr.load_repertoire(self.rep_good, validate=True)
+            data = airr.load_repertoire(self.rep_bad, validate=True, debug=True)
             self.assertFalse(True, 'load_repertoire(): bad data failed')
-        except:
+        except ValidationError:
             pass
+        except Exception as inst:
+            print(type(inst))
+            raise inst
 
 if __name__ == '__main__':
     unittest.main()

--- a/lang/python/tests/test_io.py
+++ b/lang/python/tests/test_io.py
@@ -21,6 +21,7 @@ class TestRearrangementReader(unittest.TestCase):
         # Test data
         self.data_good = os.path.join(data_path, 'good_data.tsv')
         self.data_bad = os.path.join(data_path, 'bad_data.tsv')
+        self.data_extra = os.path.join(data_path, 'extra_data.tsv')
 
         # Start timer
         self.start = time.time()
@@ -47,8 +48,24 @@ class TestRearrangementReader(unittest.TestCase):
                 for r in reader:
                     pass
             self.assertFalse(True, 'validate(): bad data failed')
-        except:
+        except ValidationError:
             pass
+        except Exception as inst:
+            print(type(inst))
+            raise inst
+
+        # Extra data
+        try:
+            with open(self.data_extra, 'r') as handle:
+                reader = RearrangementReader(handle, validate=False)
+                for r in reader:
+                    pass
+            self.assertFalse(True, 'validate(): extra data failed')
+        except ValueError:
+            pass
+        except Exception as inst:
+            print(type(inst))
+            raise inst
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fixes #457 

This gives a proper validation error now, and also should not abort when reading such a file.

```
$ airr-tools validate rearrangement -a my_airr.txt 
Validating: my_airr.txt
my_airr.txt at record 1 has validation error: row has extra data
```

A related question is if `airr.read_rearrangement`, when not validating, should it do something under the circumstance? Print a warning, fail, remove the data entry, leave as is? Right now it returns the row entry with a null header name:

```
OrderedDict([('sequence_id', '1'), ('sequence', '2'), ('rev_comp', False), ('productive', False), ('v_call', '5'), ('d_call', '6'), ('j_call', '7'), ('sequence_alignment', '8'), ('germline_alignment', '9'), ('junction', '11'), ('junction_aa', '12'), ('v_cigar', '13'), ('d_cigar', '14'), ('j_cigar', '15'), (None, ['not_in_header'])])
```