### PR TITLE
schema for AIRR data file

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -139,6 +139,88 @@ Attributes:
                             type: string
                             description: Ontology name for the top node term
 
+# AIRR Data File
+#
+# A JSON data file that holds Repertoire metadata, data processing
+# analysis objects, or any object in the AIRR Data Model.
+#
+# It is presumed that the objects gathered together in an AIRR Data File are related
+# or relevant to each other, e.g. part of the same study; thus, the ID fields can be
+# internally resolved unless the ID contains an external PID. This implies that AIRR
+# Data Files cannot be merged simply by concatenating arrays; any merge program
+# would need to manage duplicate or conflicting ID values.
+
+DataFile:
+    discriminator: AIRR
+    type: object
+    properties:
+        Info:
+            $ref: '#/InfoObject'
+        Repertoire:
+            type: array
+            description: List of Repertoire metadata
+            items:
+              $ref: '#/Repertoire'
+        Germline:
+            type: array
+            description: Germline sets
+            items:
+              $ref: '#/GermlineSet'
+        DataProcessing:
+            type: array
+            description: List of data processing workflows
+            items:
+              $ref: '#/DataProcessing'
+        Cell:
+            type: array
+            description: List of cells
+            items:
+              $ref: '#/Cell'
+        Rearrangement:
+            type: array
+            description: List of rearrangement records
+            items:
+              $ref: '#/Rearrangement'
+        Clone:
+            type: array
+            description: List of clones
+            items:
+              $ref: '#/Clone'
+        Tree:
+            type: array
+            description: List of trees
+            items:
+              $ref: '#/Tree'
+
+# AIRR Info object, should be similar to openapi
+# should we point to an openapi schema?
+InfoObject:
+    type: object
+    description: Provides information about data and API responses.
+    properties:
+      title:
+        type: string
+      version:
+        type: string
+      description:
+        type: string
+      contact:
+        type: object
+        properties:
+          name:
+            type: string
+          url:
+            type: string
+          email:
+            type: string
+      license:
+        type: object
+        properties:
+          name:
+            type: string
+          url:
+            type: string
+
 #
 # Germline gene schema
 #

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -161,11 +161,6 @@ DataFile:
             description: List of Repertoire metadata
             items:
               $ref: '#/Repertoire'
-        Germline:
-            type: array
-            description: Germline sets
-            items:
-              $ref: '#/GermlineSet'
         DataProcessing:
             type: array
             description: List of data processing workflows
@@ -195,6 +190,7 @@ DataFile:
 # AIRR Info object, should be similar to openapi
 # should we point to an openapi schema?
 InfoObject:
+    discriminator: AIRR
     type: object
     description: Provides information about data and API responses.
     properties:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -139,6 +139,88 @@ Attributes:
                             type: string
                             description: Ontology name for the top node term
 
+# AIRR Data File
+#
+# A JSON data file that holds Repertoire metadata, data processing
+# analysis objects, or any object in the AIRR Data Model.
+#
+# It is presumed that the objects gathered together in an AIRR Data File are related
+# or relevant to each other, e.g. part of the same study; thus, the ID fields can be
+# internally resolved unless the ID contains an external PID. This implies that AIRR
+# Data Files cannot be merged simply by concatenating arrays; any merge program
+# would need to manage duplicate or conflicting ID values.
+
+DataFile:
+    discriminator: AIRR
+    type: object
+    properties:
+        Info:
+            $ref: '#/InfoObject'
+        Repertoire:
+            type: array
+            description: List of Repertoire metadata
+            items:
+              $ref: '#/Repertoire'
+        Germline:
+            type: array
+            description: Germline sets
+            items:
+              $ref: '#/GermlineSet'
+        DataProcessing:
+            type: array
+            description: List of data processing workflows
+            items:
+              $ref: '#/DataProcessing'
+        Cell:
+            type: array
+            description: List of cells
+            items:
+              $ref: '#/Cell'
+        Rearrangement:
+            type: array
+            description: List of rearrangement records
+            items:
+              $ref: '#/Rearrangement'
+        Clone:
+            type: array
+            description: List of clones
+            items:
+              $ref: '#/Clone'
+        Tree:
+            type: array
+            description: List of trees
+            items:
+              $ref: '#/Tree'
+
+# AIRR Info object, should be similar to openapi
+# should we point to an openapi schema?
+InfoObject:
+    type: object
+    description: Provides information about data and API responses.
+    properties:
+      title:
+        type: string
+      version:
+        type: string
+      description:
+        type: string
+      contact:
+        type: object
+        properties:
+          name:
+            type: string
+          url:
+            type: string
+          email:
+            type: string
+      license:
+        type: object
+        properties:
+          name:
+            type: string
+          url:
+            type: string
+
 #
 # Germline gene schema
 #

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -161,11 +161,6 @@ DataFile:
             description: List of Repertoire metadata
             items:
               $ref: '#/Repertoire'
-        Germline:
-            type: array
-            description: Germline sets
-            items:
-              $ref: '#/GermlineSet'
         DataProcessing:
             type: array
             description: List of data processing workflows
@@ -195,6 +190,7 @@ DataFile:
 # AIRR Info object, should be similar to openapi
 # should we point to an openapi schema?
 InfoObject:
+    discriminator: AIRR
     type: object
     description: Provides information about data and API responses.
     properties:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -139,6 +139,86 @@ Attributes:
                             type: string
                             description: Ontology name for the top node term
 
+# AIRR Data File
+#
+# A JSON data file that holds Repertoire metadata, data processing
+# analysis objects, or any object in the AIRR Data Model.
+#
+# It is presumed that the objects gathered together in an AIRR Data File are related
+# or relevant to each other, e.g. part of the same study; thus, the ID fields can be
+# internally resolved unless the ID contains an external PID. This implies that AIRR
+# Data Files cannot be merged simply by concatenating arrays; any merge program
+# would need to manage duplicate or conflicting ID values.
+
+DataFile:
+    discriminator:
+        propertyName: AIRR
+    type: object
+    properties:
+        Info:
+            $ref: '#/InfoObject'
+        Repertoire:
+            type: array
+            description: List of Repertoire metadata
+            items:
+              $ref: '#/Repertoire'
+        DataProcessing:
+            type: array
+            description: List of data processing workflows
+            items:
+              $ref: '#/DataProcessing'
+        Cell:
+            type: array
+            description: List of cells
+            items:
+              $ref: '#/Cell'
+        Rearrangement:
+            type: array
+            description: List of rearrangement records
+            items:
+              $ref: '#/Rearrangement'
+        Clone:
+            type: array
+            description: List of clones
+            items:
+              $ref: '#/Clone'
+        Tree:
+            type: array
+            description: List of trees
+            items:
+              $ref: '#/Tree'
+
+# AIRR Info object, should be similar to openapi
+# should we point to an openapi schema?
+InfoObject:
+    discriminator:
+        propertyName: AIRR
+    type: object
+    description: Provides information about data and API responses.
+    properties:
+      title:
+        type: string
+      version:
+        type: string
+      description:
+        type: string
+      contact:
+        type: object
+        properties:
+          name:
+            type: string
+          url:
+            type: string
+          email:
+            type: string
+      license:
+        type: object
+        properties:
+          name:
+            type: string
+          url:
+            type: string
+
 #
 # Germline gene schema
 #

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -139,6 +139,88 @@ Attributes:
                             type: string
                             description: Ontology name for the top node term
 
+# AIRR Data File
+#
+# A JSON data file that holds Repertoire metadata, data processing
+# analysis objects, or any object in the AIRR Data Model.
+#
+# It is presumed that the objects gathered together in an AIRR Data File are related
+# or relevant to each other, e.g. part of the same study; thus, the ID fields can be
+# internally resolved unless the ID contains an external PID. This implies that AIRR
+# Data Files cannot be merged simply by concatenating arrays; any merge program
+# would need to manage duplicate or conflicting ID values.
+
+DataFile:
+    discriminator: AIRR
+    type: object
+    properties:
+        Info:
+            $ref: '#/InfoObject'
+        Repertoire:
+            type: array
+            description: List of Repertoire metadata
+            items:
+              $ref: '#/Repertoire'
+        Germline:
+            type: array
+            description: Germline sets
+            items:
+              $ref: '#/GermlineSet'
+        DataProcessing:
+            type: array
+            description: List of data processing workflows
+            items:
+              $ref: '#/DataProcessing'
+        Cell:
+            type: array
+            description: List of cells
+            items:
+              $ref: '#/Cell'
+        Rearrangement:
+            type: array
+            description: List of rearrangement records
+            items:
+              $ref: '#/Rearrangement'
+        Clone:
+            type: array
+            description: List of clones
+            items:
+              $ref: '#/Clone'
+        Tree:
+            type: array
+            description: List of trees
+            items:
+              $ref: '#/Tree'
+
+# AIRR Info object, should be similar to openapi
+# should we point to an openapi schema?
+InfoObject:
+    type: object
+    description: Provides information about data and API responses.
+    properties:
+      title:
+        type: string
+      version:
+        type: string
+      description:
+        type: string
+      contact:
+        type: object
+        properties:
+          name:
+            type: string
+          url:
+            type: string
+          email:
+            type: string
+      license:
+        type: object
+        properties:
+          name:
+            type: string
+          url:
+            type: string
+
 #
 # Germline gene schema
 #

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -161,11 +161,6 @@ DataFile:
             description: List of Repertoire metadata
             items:
               $ref: '#/Repertoire'
-        Germline:
-            type: array
-            description: Germline sets
-            items:
-              $ref: '#/GermlineSet'
         DataProcessing:
             type: array
             description: List of data processing workflows
@@ -195,6 +190,7 @@ DataFile:
 # AIRR Info object, should be similar to openapi
 # should we point to an openapi schema?
 InfoObject:
+    discriminator: AIRR
     type: object
     description: Provides information about data and API responses.
     properties:


### PR DESCRIPTION
An explicit schema for an AIRR data(metadata) file. This is an extension of the file format for Repertoire metadata (which just has the `Info` and `Repertoire` keys) to include the additional AIRR objects. The format continues the earlier design where the output from the ADC API exactly matches the file format. Also an `Info` object schema is provided. This was previously only in the ADC API spec.

`Rearrangement` implies rearrangement data in JSON (versus TSV). We might want to consider how to extend this format for #426 so that the data file can refer to TSV files.

This shows how `DataProcessing` can be a "top-level" object.
