### PR TITLE
Issue 475 and 433

### DIFF
--- a/lang/R/DESCRIPTION
+++ b/lang/R/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: airr
 Type: Package
-Version: 1.4.0-dev
+Version: 1.4.0
 Date: 2021-03-21
 Authors@R: c(person("Jason", "Vander Heiden", role=c("aut", "cre"), 
                     email="jason.vanderheiden@gmail.com"),

--- a/lang/R/DESCRIPTION
+++ b/lang/R/DESCRIPTION
@@ -1,13 +1,15 @@
 Package: airr
 Type: Package
 Version: 1.3.0
-Date: 2020-05-26
+Date: 2021-03-21
 Authors@R: c(person("Jason", "Vander Heiden", role=c("aut", "cre"), 
                     email="jason.vanderheiden@gmail.com"),
              person("Susanna", "Marquez", role=c("aut"), 
                     email="susanna.marquez@yale.edu"),
              person("Scott", "Christley", role=c("aut"), 
                     email="Scott.Christley@UTSouthwestern.edu"),
+             person("Ulrik", " Stervbo", role=c("aut"),
+                    email="ulrik.stervbo@elisabethgruppe.de"),
              person("AIRR Community", role=c("cph")))
 Title: AIRR Data Representation Reference Library
 Description: Schema definitions and read, write and validation tools for data 

--- a/lang/R/DESCRIPTION
+++ b/lang/R/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: airr
 Type: Package
-Version: 1.3.0
+Version: 1.4.0-dev
 Date: 2021-03-21
 Authors@R: c(person("Jason", "Vander Heiden", role=c("aut", "cre"), 
                     email="jason.vanderheiden@gmail.com"),
@@ -34,4 +34,4 @@ Suggests:
     knitr,
     rmarkdown,
     testthat
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/lang/R/NEWS.md
+++ b/lang/R/NEWS.md
@@ -1,3 +1,10 @@
+Version 1.4.0:  In development
+-------------------------------------------------------------------------------
+    
++ Added the `aux_types` argument to `read_airr` (and dependent functions) to
+  allow explicit declaration of the type for fields that are not defined
+  in the schema.
+
 Version 1.3.0:  May 26, 2020
 -------------------------------------------------------------------------------
     

--- a/lang/R/NEWS.md
+++ b/lang/R/NEWS.md
@@ -1,4 +1,4 @@
-Version 1.4.0:  In development
+Version 1.4.0-dev:  In development
 -------------------------------------------------------------------------------
     
 + Added the `aux_types` argument to `read_airr` (and dependent functions) to

--- a/lang/R/R/Interface.R
+++ b/lang/R/R/Interface.R
@@ -11,6 +11,8 @@
 #'                   are 0-based half-open intervals (python style) in the input file
 #'                   and will be converted to 1-based closed-intervals (R style).
 #' @param    schema  \code{Schema} object defining the output format.
+#' @param    aux_col_types A named vector or list giving the class of non-schema
+#'                   columns. The column name is the name, the value the class.
 #' @param    ...     additional arguments to pass to \link[readr]{read_delim}.
 #'
 #' @return   A data.frame of the TSV file with appropriate type and position conversion
@@ -28,7 +30,7 @@
 #' df <- read_rearrangement(file)
 #'
 #' @export
-read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, ...) {
+read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, aux_col_types = NULL, ...) {
     # Check arguments
     base <- match.arg(base)
 
@@ -38,6 +40,12 @@ read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, ...) {
     schema_fields <- intersect(names(schema), header)
     cast <- setNames(lapply(schema_fields, function(f) parsers[schema[f]$type]), schema_fields)
     cast <- c(cast, list(.default = col_character()))
+
+    if(!is.null(aux_col_types)){
+        aux_cols <- setNames(lapply(aux_col_types, function(f) parsers[f]), names(aux_col_types))
+        cast <- c(cast, aux_cols)
+    }
+
     types <- do.call(readr::cols, cast)
 
     # Read file

--- a/lang/R/R/Interface.R
+++ b/lang/R/R/Interface.R
@@ -30,12 +30,12 @@
 #' df <- read_rearrangement(file)
 #'
 #' @export
-read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, aux_col_types = NULL, ...) {
+read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, aux_col_types=NULL, ...) {
     # Check arguments
     base <- match.arg(base)
 
     # Define types
-    parsers <- c("character"="c", "logical"="l", "integer"="i", "double"="d")
+    parsers <- c("character"="c", "logical"="l", "integer"="i", "double"="d", "numeric"="n")
     header <- names(suppressMessages(readr::read_tsv(file, n_max=1)))
     schema_fields <- intersect(names(schema), header)
     cast <- setNames(lapply(schema_fields, function(f) parsers[schema[f]$type]), schema_fields)

--- a/lang/R/R/Interface.R
+++ b/lang/R/R/Interface.R
@@ -1,50 +1,51 @@
 #### Rearrangement I/O ####
 
 #' Read an AIRR TSV
-#' 
+#'
 #' \code{read_airr} reads a TSV containing AIRR records.
 #'
 #' @param    file    input file path.
-#' @param    base    starting index for positional fields in the input file. 
+#' @param    base    starting index for positional fields in the input file.
 #'                   If \code{"1"}, then these fields will not be modified.
 #'                   If \code{"0"}, then fields ending in \code{"_start"} and \code{"_end"}
-#'                   are 0-based half-open intervals (python style) in the input file 
+#'                   are 0-based half-open intervals (python style) in the input file
 #'                   and will be converted to 1-based closed-intervals (R style).
 #' @param    schema  \code{Schema} object defining the output format.
 #' @param    ...     additional arguments to pass to \link[readr]{read_delim}.
-#' 
+#'
 #' @return   A data.frame of the TSV file with appropriate type and position conversion
 #'           for fields defined in the specification.
-#'                   
-#' @seealso  
+#'
+#' @seealso
 #' See \link{Schema} for the AIRR schema object definition.
 #' See \link{write_airr} for writing AIRR data.
-#' 
+#'
 #' @examples
 #' # Get path to the rearrangement-example file
 #' file <- system.file("extdata", "rearrangement-example.tsv.gz", package="airr")
-#' 
+#'
 #' # Load data file
 #' df <- read_rearrangement(file)
-#' 
+#'
 #' @export
 read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, ...) {
     # Check arguments
     base <- match.arg(base)
-    
+
     # Define types
     parsers <- c("character"="c", "logical"="l", "integer"="i", "double"="d")
     header <- names(suppressMessages(readr::read_tsv(file, n_max=1)))
     schema_fields <- intersect(names(schema), header)
     cast <- setNames(lapply(schema_fields, function(f) parsers[schema[f]$type]), schema_fields)
+    cast <- c(cast, list(.default = col_character()))
     types <- do.call(readr::cols, cast)
-    
+
     # Read file
     data <- suppressMessages(readr::read_tsv(file, col_types=types, na=c("", "NA", "None"), ...))
-    
+
     # Validate file
     valid_data <- validate_airr(data, schema=schema)
-    
+
     # Adjust indexes
     if (base == "0") {
         start_positions <- grep("_start$", names(data), perl=TRUE)
@@ -58,8 +59,8 @@ read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, ...) {
 
 
 #' Validate AIRR data
-#' 
-#' \code{validate_airr} validates compliance of the contents of a data.frame 
+#'
+#' \code{validate_airr} validates compliance of the contents of a data.frame
 #' to the AIRR data standards.
 #'
 #' @param    data    data.frame to validate.
@@ -67,32 +68,32 @@ read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, ...) {
 #'
 #' @return   Returns \code{TRUE} if the input \code{data} is compliant and
 #'           \code{FALSE} if not.
-#'           
+#'
 #' @examples
 #' # Get path to the rearrangement-example file
 #' file <- system.file("extdata", "rearrangement-example.tsv.gz", package="airr")
-#' 
+#'
 #' # Load data file
 #' df <- read_rearrangement(file)
-#' 
+#'
 #' # Validate a data.frame against the Rearrangement schema
 #' validate_airr(df, schema=RearrangementSchema)
-#' 
+#'
 #' @export
 validate_airr <- function(data, schema=RearrangementSchema){
-    
+
     valid <- TRUE
-    
+
     # Check all required fields exist
     missing_fields <- setdiff(schema@required, colnames(data))
-    
+
     if (length(missing_fields) > 0 ) {
         valid <- FALSE
         warning(paste("Warning: File is missing AIRR mandatory field(s):",
                       paste(missing_fields, collapse = ", ")))
     }
-    
-   # Validate sequence_id: 
+
+   # Validate sequence_id:
    # - uniqueness
    # - not empty
    if ("sequence_id" %in% colnames(data)) {
@@ -107,12 +108,12 @@ validate_airr <- function(data, schema=RearrangementSchema){
            # TODO
            # valid <- FALSE
            warning(paste("Warning: sequence_id is empty for row(s):",
-                         paste(empty_rows, collapse = ", ")))           
+                         paste(empty_rows, collapse = ", ")))
        }
    }
-    
+
     # check logical fields
-    logical_fields <- names(which(sapply(schema@properties, 
+    logical_fields <- names(which(sapply(schema@properties,
                                          '[[', "type") == "logical"))
     logical_fields <- intersect(colnames(data), logical_fields)
     if (length(logical_fields) > 0 ) {
@@ -120,19 +121,19 @@ validate_airr <- function(data, schema=RearrangementSchema){
             not_logical <- data[[log_field]] %in% c(TRUE, FALSE) == FALSE
             if (any(not_logical)) {
                 warning(paste("Warning:",log_field,"is not logical for row(s):",
-                              paste(which(not_logical), collapse = ", ")))            
+                              paste(which(not_logical), collapse = ", ")))
             } else {
                 NULL
             }
         }
     }
-    
+
     valid
 }
 
 #' @details
 #' \code{read_rearrangement} reads an AIRR TSV containing Rearrangement data.
-#' 
+#'
 #' @rdname read_airr
 #' @export
 read_rearrangement <- function(file, base=c("1", "0"), ...) {
@@ -142,7 +143,7 @@ read_rearrangement <- function(file, base=c("1", "0"), ...) {
 
 #' @details
 #' \code{read_alignment} reads an AIRR TSV containing Alignment data.
-#' 
+#'
 #' @rdname read_airr
 #' @export
 read_alignment <- function(file, base=c("1", "0"), ...) {
@@ -151,60 +152,60 @@ read_alignment <- function(file, base=c("1", "0"), ...) {
 
 
 #' Write an AIRR TSV
-#' 
+#'
 #' \code{write_airr} writes a TSV containing AIRR formatted records.
 #'
 #' @param    data    data.frame of Rearrangement data.
 #' @param    file    output file name.
-#' @param    base    starting index for positional fields in the output file. 
-#'                   Fields in the input \code{data} are assumed to be 1-based 
-#'                   closed-intervals (R style). 
-#'                   If \code{"1"}, then these fields will not be modified. 
+#' @param    base    starting index for positional fields in the output file.
+#'                   Fields in the input \code{data} are assumed to be 1-based
+#'                   closed-intervals (R style).
+#'                   If \code{"1"}, then these fields will not be modified.
 #'                   If \code{"0"}, then fields ending in \code{_start} and \code{_end}
-#'                   will be converted to 0-based half-open intervals (python style) 
-#'                   in the output file. 
+#'                   will be converted to 0-based half-open intervals (python style)
+#'                   in the output file.
 #' @param    schema  \code{Schema} object defining the output format.
 #' @param    ...     additional arguments to pass to \link[readr]{write_delim}.
 #'
 #' @return   NULL
-#' 
+#'
 #' @seealso
 #' See \link{Schema} for the AIRR schema object definition.
 #' See \link{read_airr} for reading to AIRR files.
-#' 
+#'
 #' @examples
 #' # Get path to the rearrangement-example file
 #' file <- system.file("extdata", "rearrangement-example.tsv.gz", package="airr")
-#' 
+#'
 #' # Load data file
 #' df <- read_rearrangement(file)
-#' 
+#'
 #' # Write a Rearrangement data file
 #' outfile <- file.path(tempdir(), "output.tsv")
 #' write_rearrangement(df, outfile)
-#' 
+#'
 #' @export
 write_airr <- function(data, file, base=c("1", "0"), schema=RearrangementSchema, ...) {
     ## DEBUG
     # data <- data.frame("sequence_id"=1:4, "extra"=1:4, "a"=LETTERS[1:4])
-    
+
     data_name <- deparse(substitute(data))
     schema_name <- deparse(substitute(schema))
-    
+
     # Check arguments
     base <- match.arg(base)
-    
+
     # Fill in missing required columns
     missing <- setdiff(schema@required, names(data))
     if (length(missing) > 0 ) {
         data[, missing] <- NA
     }
-    
+
     # order columns
     ordering <- c(intersect(names(schema), names(data)),
                   setdiff(names(data), names(schema)))
     data <- data[, ordering]
-    
+
     # Adjust indexes
     if (base == "0") {
         start_positions <- grep("_start$", names(data), perl=TRUE)
@@ -212,7 +213,7 @@ write_airr <- function(data, file, base=c("1", "0"), schema=RearrangementSchema,
             data[, start_positions] <- data[, start_positions] - 1
         }
     }
-    
+
     valid <- suppressWarnings(validate_airr(data, schema))
     if (!valid) {
         w <- names(warnings())
@@ -221,10 +222,10 @@ write_airr <- function(data, file, base=c("1", "0"), schema=RearrangementSchema,
         err_msg <- paste(err_msg, paste(w, collapse = "\n"))
         warning(err_msg)
     }
-    
+
 
     # write logical fields as T/F
-    logical_fields <- names(which(sapply(schema@properties, 
+    logical_fields <- names(which(sapply(schema@properties,
                                          '[[', "type") == "logical"))
     logical_fields <- intersect(colnames(data), logical_fields)
     if (length(logical_fields) > 0 ) {
@@ -237,7 +238,7 @@ write_airr <- function(data, file, base=c("1", "0"), schema=RearrangementSchema,
             }
         }
     }
-    
+
     # Write
     write_tsv(data, file, na="", ...)
 }
@@ -245,7 +246,7 @@ write_airr <- function(data, file, base=c("1", "0"), schema=RearrangementSchema,
 
 #' @details
 #' \code{write_rearrangement} writes a data.frame containing AIRR Rearrangement data to TSV.
-#' 
+#'
 #' @rdname write_airr
 #' @export
 write_rearrangement <- function(data, file, base=c("1", "0"), ...) {
@@ -255,7 +256,7 @@ write_rearrangement <- function(data, file, base=c("1", "0"), ...) {
 
 #' @details
 #' \code{write_alignment} writes a data.frame containing AIRR Alignment data to TSV.
-#' 
+#'
 #' @rdname write_airr
 #' @export
 write_alignment <- function(data, file, base=c("1", "0"), ...) {

--- a/lang/R/R/Interface.R
+++ b/lang/R/R/Interface.R
@@ -4,16 +4,18 @@
 #'
 #' \code{read_airr} reads a TSV containing AIRR records.
 #'
-#' @param    file    input file path.
-#' @param    base    starting index for positional fields in the input file.
-#'                   If \code{"1"}, then these fields will not be modified.
-#'                   If \code{"0"}, then fields ending in \code{"_start"} and \code{"_end"}
-#'                   are 0-based half-open intervals (python style) in the input file
-#'                   and will be converted to 1-based closed-intervals (R style).
-#' @param    schema  \code{Schema} object defining the output format.
-#' @param    aux_col_types A named vector or list giving the class of non-schema
-#'                   columns. The column name is the name, the value the class.
-#' @param    ...     additional arguments to pass to \link[readr]{read_delim}.
+#' @param    file        input file path.
+#' @param    base        starting index for positional fields in the input file.
+#'                       If \code{"1"}, then these fields will not be modified.
+#'                       If \code{"0"}, then fields ending in \code{"_start"} and \code{"_end"}
+#'                       are 0-based half-open intervals (python style) in the input file
+#'                       and will be converted to 1-based closed-intervals (R style).
+#' @param    schema      \code{Schema} object defining the output format.
+#' @param    aux_types   named vector or list giving the type for fields that are not
+#'                       defined in \code{schema}. The field name is the name, the value
+#'                       the type, denoted by one of \code{"c"} (character), \code{"l"} (logical),
+#'                       \code{"i"} (integer), \code{"d"} (double), or \code{"n"} (numeric).
+#' @param    ...         additional arguments to pass to \link[readr]{read_delim}.
 #'
 #' @return   A data.frame of the TSV file with appropriate type and position conversion
 #'           for fields defined in the specification.
@@ -30,7 +32,7 @@
 #' df <- read_rearrangement(file)
 #'
 #' @export
-read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, aux_col_types=NULL, ...) {
+read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, aux_types=NULL, ...) {
     # Check arguments
     base <- match.arg(base)
 
@@ -41,9 +43,9 @@ read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, aux_co
     cast <- setNames(lapply(schema_fields, function(f) parsers[schema[f]$type]), schema_fields)
     cast <- c(cast, list(.default = col_character()))
 
-    if(!is.null(aux_col_types)){
-        aux_col_types <- aux_col_types[names(aux_col_types) %in% header]
-        aux_cols <- setNames(lapply(aux_col_types, function(f) parsers[f]), names(aux_col_types))
+    if(!is.null(aux_types)){
+        aux_types <- aux_types[names(aux_types) %in% header]
+        aux_cols <- setNames(lapply(aux_types, function(f) parsers[f]), names(aux_types))
         cast <- c(cast, aux_cols)
     }
 

--- a/lang/R/R/Interface.R
+++ b/lang/R/R/Interface.R
@@ -42,6 +42,7 @@ read_airr <- function(file, base=c("1", "0"), schema=RearrangementSchema, aux_co
     cast <- c(cast, list(.default = col_character()))
 
     if(!is.null(aux_col_types)){
+        aux_col_types <- aux_col_types[names(aux_col_types) %in% header]
         aux_cols <- setNames(lapply(aux_col_types, function(f) parsers[f]), names(aux_col_types))
         cast <- c(cast, aux_cols)
     }

--- a/lang/R/tests/testthat/test-Interface.R
+++ b/lang/R/tests/testthat/test-Interface.R
@@ -74,6 +74,14 @@ test_that("Columns are of expected type", {
     expect_is(tbl_0$extra.numeric, "character")
     expect_is(tbl_0$extra.character, "character")
 
+    expect_is(read_airr(
+        rearrangement_file, "1",
+        aux_col_types =
+            c(extra.int = "integer",
+              extra.double = "double",
+              extra.numeric = "numeric",
+              extra.character = "character")), "data.frame")
+
     expect_is(tbl_0 <- read_airr(
         tmp_file, "1",
         aux_col_types =

--- a/lang/R/tests/testthat/test-Interface.R
+++ b/lang/R/tests/testthat/test-Interface.R
@@ -8,7 +8,7 @@ bad_rearrangement_file <- file.path("..", "data-tests", "bad_data.tsv")
 
 # Expected warnings for bad_rearrangement_file
 expected_w <- c(
-    "Warning: File is missing AIRR mandatory field(s): sequence",            
+    "Warning: File is missing AIRR mandatory field(s): sequence",
     "Warning: sequence_id(s) are not unique: IVKNQEJ01AJ44V, IVKNQEJ01AJ44V",
     "Warning: sequence_id is empty for row(s): 7",
     "Warning: rev_comp is not logical for row(s): 4",
@@ -31,6 +31,46 @@ test_that("read_arirr applies base", {
     expect_true(validate_airr(tbl_0))
     start_positions <- grep("_start$", names(tbl_0), perl=TRUE)
     expect_equivalent(tbl_0[, start_positions] - 1, tbl_1[, start_positions])
+})
+
+test_that("Columns are of expected type", {
+    # Create test data
+    tmp_file <- tempfile(fileext = ".tsv")
+
+    tbl_0 <- read_airr(rearrangement_file, "1")
+
+    # Create non-schema  columns
+    extra_cols <- data.frame(
+        extra.int = c(1:nrow(tbl_0)),
+        extra.numeric = rnorm(nrow(tbl_0)),
+        extra.character = stringi::stri_rand_strings(nrow(tbl_0), 6)
+    )
+    extra_cols_na <- data.frame(
+        extra.int = NA,
+        extra.numeric = NA,
+        extra.character = NA
+    )
+
+    # Get the number of replications to create a data.frame with NAs to make
+    # guessing of column type fail (all NAs)
+    num_rep <- ceiling(1000/nrow(tbl_0)) + 1
+    tbl_1 <- do.call(
+        "rbind",
+        replicate(num_rep,
+                  cbind(tbl_0, extra_cols_na),
+                  simplify = FALSE))
+    # Make all sequence_id unique
+    tbl_1$sequence_id <- c(1:nrow(tbl_1))
+
+    tbl_0 <- cbind(tbl_0, extra_cols)
+    tbl_0 <- rbind(tbl_1, tbl_0)
+    write_tsv(tbl_0, tmp_file)
+
+    # Read with col_character() as default
+    expect_is(tbl_0 <- read_airr(tmp_file, "1"), "data.frame")
+    expect_is(tbl_0$extra.int, "character")
+    expect_is(tbl_0$extra.numeric, "character")
+    expect_is(tbl_0$extra.character, "character")
 })
 
 

--- a/lang/R/tests/testthat/test-Interface.R
+++ b/lang/R/tests/testthat/test-Interface.R
@@ -71,6 +71,16 @@ test_that("Columns are of expected type", {
     expect_is(tbl_0$extra.int, "character")
     expect_is(tbl_0$extra.numeric, "character")
     expect_is(tbl_0$extra.character, "character")
+
+    expect_is(tbl_0 <- read_airr(
+        tmp_file, "1",
+        aux_col_types =
+            c(extra.int = "integer",
+              extra.numeric = "double",
+              extra.character = "character")), "data.frame")
+    expect_is(tbl_0$extra.int, "integer")
+    expect_is(tbl_0$extra.numeric, "numeric")
+    expect_is(tbl_0$extra.character, "character")
 })
 
 

--- a/lang/R/tests/testthat/test-Interface.R
+++ b/lang/R/tests/testthat/test-Interface.R
@@ -43,11 +43,13 @@ test_that("Columns are of expected type", {
     extra_cols <- data.frame(
         extra.int = c(1:nrow(tbl_0)),
         extra.numeric = rnorm(nrow(tbl_0)),
+        extra.double = rnorm(nrow(tbl_0)),
         extra.character = stringi::stri_rand_strings(nrow(tbl_0), 6)
     )
     extra_cols_na <- data.frame(
         extra.int = NA,
         extra.numeric = NA,
+        extra.double = NA,
         extra.character = NA
     )
 
@@ -76,11 +78,14 @@ test_that("Columns are of expected type", {
         tmp_file, "1",
         aux_col_types =
             c(extra.int = "integer",
-              extra.numeric = "double",
+              extra.double = "double",
+              extra.numeric = "numeric",
               extra.character = "character")), "data.frame")
     expect_is(tbl_0$extra.int, "integer")
+    expect_is(tbl_0$extra.double, "numeric")
     expect_is(tbl_0$extra.numeric, "numeric")
     expect_is(tbl_0$extra.character, "character")
+
 })
 
 

--- a/lang/R/tests/testthat/test-Interface.R
+++ b/lang/R/tests/testthat/test-Interface.R
@@ -76,7 +76,7 @@ test_that("Columns are of expected type", {
 
     expect_is(read_airr(
         rearrangement_file, "1",
-        aux_col_types =
+        aux_types =
             c(extra.int = "integer",
               extra.double = "double",
               extra.numeric = "numeric",
@@ -84,7 +84,7 @@ test_that("Columns are of expected type", {
 
     expect_is(tbl_0 <- read_airr(
         tmp_file, "1",
-        aux_col_types =
+        aux_types =
             c(extra.int = "integer",
               extra.double = "double",
               extra.numeric = "numeric",


### PR DESCRIPTION
Add argument to `airr::read_airr()` to define the type of non-schema columns, with character as default.

Fitting unit test is added. Test data created on the fly from toy_data.tsv

Closes #475 and #433 