### PR TITLE
Add ADC specific gene and subgroup query fields

### DIFF
--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -121,39 +121,40 @@ components:
             type: integer
   
     # list of rearrangement extension fields
-    rearrangement_extension_fields:
-      type: object
-      properties:
-        adc_v_subgroup:
-          type: string
-          description: >
-            V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-            the relevant gene nomenclature should be followed (e.g., IGHV4).
-          example: IGHV4
-          x-airr:
-            nullable: true
-            adc-api-optional: false
-            adc-query_support: true
-            name: V gene subgroup
-        adc_v_gene:
-          type: string
-          description: >
-            V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-            the relevant gene nomenclature should be followed (e.g., IGHV4-59).
-          example: IGHV4-59
-          x-airr:
-            nullable: true
-            adc-api-optional: false
-            adc-query_support: true
-            name: V gene  
+    rearrangement_extension:
+      description: The extended Rearrangement object with additional query fields for the ADC.
+      allOf:
+        - $ref: https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Rearrangement
+        - type: object
+          properties:
+            adc_v_subgroup:
+              type: string
+              description: >
+                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4).
+              example: IGHV4
+              x-airr:
+                nullable: true
+                adc-api-optional: false
+                adc-query_support: true
+                name: V gene subgroup
+            adc_v_gene:
+              type: string
+              description: >
+                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+              example: IGHV4-59
+              x-airr:
+                nullable: true
+                adc-api-optional: false
+                adc-query_support: true
+                name: V gene
   
   # list of rearrangement annotations
     rearrangement_list:
       type: array
       items:
-        allOf:
-          - $ref: https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Rearrangement
-          - $ref: '#/components/schemas/rearrangement_extension_fields'
+        $ref: '#/components/schemas/rearrangement_extension'
 
     # list of clone annotations
     clone_list:

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -120,32 +120,32 @@ components:
           count:
             type: integer
   
-  # list of rearrangement extension fields
-  rearrangement_extension_fields:
-    type: object
-    properties:
-      adc_v_subgroup:
-        type: string
-        description: >
-          V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-          the relevant gene nomenclature should be followed (e.g., IGHV4).
-        example: IGHV4
-        x-airr:
-          nullable: true
-          adc-api-optional: false
-          adc-query_support: true
-          name: V gene subgroup
-      adc_v_gene:
-        type: string
-        description: >
-          V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-          the relevant gene nomenclature should be followed (e.g., IGHV4-59).
-        example: IGHV4-59
-        x-airr:
-          nullable: true
-          adc-api-optional: false
-          adc-query_support: true
-          name: V gene  
+    # list of rearrangement extension fields
+    rearrangement_extension_fields:
+      type: object
+      properties:
+        adc_v_subgroup:
+          type: string
+          description: >
+            V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+            the relevant gene nomenclature should be followed (e.g., IGHV4).
+          example: IGHV4
+          x-airr:
+            nullable: true
+            adc-api-optional: false
+            adc-query_support: true
+            name: V gene subgroup
+        adc_v_gene:
+          type: string
+          description: >
+            V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+            the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+          example: IGHV4-59
+          x-airr:
+            nullable: true
+            adc-api-optional: false
+            adc-query_support: true
+            name: V gene  
   
   # list of rearrangement annotations
     rearrangement_list:

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -151,7 +151,9 @@ components:
     rearrangement_list:
       type: array
       items:
-        $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Rearrangement'
+        allOf:
+          - $ref: https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Rearrangement
+          - $ref: '#/components/schemas/rearrangement_extension_fields'
 
     # list of clone annotations
     clone_list:

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -149,6 +149,50 @@ components:
                 adc-api-optional: false
                 adc-query_support: true
                 name: V gene
+          adc_d_subgroup:
+            type: string
+            description: >
+              D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: D gene subgroup
+          adc_d_gene:
+            type: string
+            description: >
+              D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: D gene
+          adc_j_subgroup:
+            type: string
+            description: >
+              J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: J gene subgroup
+          adc_j_gene:
+            type: string
+            description: >
+              J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: J gene
   
   # list of rearrangement annotations
     rearrangement_list:
@@ -156,11 +200,85 @@ components:
       items:
         $ref: '#/components/schemas/rearrangement_extension'
 
+  # list of clone extension fields
+  clone_extension:
+    description: The extended Clone object with additional query fields for the ADC.
+    allOf:
+      - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Clone'
+      - type: object
+        properties:
+          adc_v_subgroup:
+            type: string
+            description: >
+              V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHV4).
+            example: IGHV4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: V gene subgroup
+          adc_v_gene:
+            type: string
+            description: >
+              V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+            example: IGHV4-59
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: V gene
+          adc_d_subgroup:
+            type: string
+            description: >
+              D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: D gene subgroup
+          adc_d_gene:
+            type: string
+            description: >
+              D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: D gene
+          adc_j_subgroup:
+            type: string
+            description: >
+              J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: J gene subgroup
+          adc_j_gene:
+            type: string
+            description: >
+              J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: J gene
+
     # list of clone annotations
     clone_list:
       type: array
       items:
-        $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Clone'
+      $ref: '#/definitions/clone_extension'
 
     # The response object /repertoire endpoint
     repertoire_response:

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -119,8 +119,35 @@ components:
         properties:
           count:
             type: integer
-          
-    # list of rearrangement annotations
+  
+  # list of rearrangement extension fields
+  rearrangement_extension_fields:
+    type: object
+    properties:
+      adc_v_subgroup:
+        type: string
+        description: >
+          V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+          the relevant gene nomenclature should be followed (e.g., IGHV4).
+        example: IGHV4
+        x-airr:
+          nullable: true
+          adc-api-optional: false
+          adc-query_support: true
+          name: V gene subgroup
+      adc_v_gene:
+        type: string
+        description: >
+          V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+          the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+        example: IGHV4-59
+        x-airr:
+          nullable: true
+          adc-api-optional: false
+          adc-query_support: true
+          name: V gene  
+  
+  # list of rearrangement annotations
     rearrangement_list:
       type: array
       items:

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -193,7 +193,29 @@ components:
               adc-api-optional: false
               adc-query_support: true
               name: J gene
-  
+            adc_c_subgroup:
+            type: string
+            description: >
+              C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: C gene subgroup
+          adc_c_gene:
+            type: string
+            description: >
+              C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: C gene
+              
   # list of rearrangement annotations
     rearrangement_list:
       type: array
@@ -273,7 +295,29 @@ components:
               adc-api-optional: false
               adc-query_support: true
               name: J gene
-
+          adc_c_subgroup:
+            type: string
+            description: >
+              C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: C gene subgroup
+          adc_c_gene:
+            type: string
+            description: >
+              C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: C gene
+              
     # list of clone annotations
     clone_list:
       type: array

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -124,7 +124,52 @@ definitions:
               adc-api-optional: false
               adc-query_support: true
               name: V gene
-  
+          adc_d_subgroup:
+            type: string
+            description: >
+              D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: D gene subgroup
+          adc_d_gene:
+            type: string
+            description: >
+              D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: D gene
+          adc_j_subgroup:
+            type: string
+            description: >
+              J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: J gene subgroup
+          adc_j_gene:
+            type: string
+            description: >
+              J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: J gene
+
+
   # list of rearrangement annotations
   rearrangement_list:
     type: array
@@ -142,11 +187,85 @@ definitions:
       Facet:
         $ref: '#/definitions/facet_list'
 
+  # list of clone extension fields
+  clone_extension:
+    description: The extended Clone object with additional query fields for the ADC.
+    allOf:
+      - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Clone'
+      - type: object
+        properties:
+          adc_v_subgroup:
+            type: string
+            description: >
+              V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHV4).
+            example: IGHV4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: V gene subgroup
+          adc_v_gene:
+            type: string
+            description: >
+              V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+            example: IGHV4-59
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: V gene
+          adc_d_subgroup:
+            type: string
+            description: >
+              D subgroup of the D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHD3).
+            example: IGHD3
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: D gene subgroup
+          adc_d_gene:
+            type: string
+            description: >
+              D gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHD3-10).
+            example: IGHD3-10
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: D gene
+          adc_j_subgroup:
+            type: string
+            description: >
+              J subgroup of the J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: J gene subgroup
+          adc_j_gene:
+            type: string
+            description: >
+              J gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHJ4).
+            example: IGHJ4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: J gene
+
   # list of clone annotations
   clone_list:
     type: array
     items:
-      $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Clone'
+      $ref: '#/definitions/rearrangement_extension'
 
   # The response object /clone/{clone_id} endpoint
   clone_id_response:

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -94,12 +94,39 @@ definitions:
         $ref: '#/definitions/repertoire_list'
       Facet:
         $ref: '#/definitions/facet_list'
-          
+        
+  # list of rearrangement extension fields
+  rearrangement_extension_fields:  
+          adc_v_subgroup:
+            type: string
+            description: >
+                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4).
+            example: IGHV4
+            x-airr:
+                nullable: true
+                adc-api-optional: false
+                adc-query_support: true
+                name: V gene subgroup
+        adc_v_gene:
+            type: string
+            description: >
+                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+            example: IGHV4-59
+            x-airr:
+                nullable: true
+                adc-api-optional: false
+                adc-query_support: true
+                name: V gene  
+  
   # list of rearrangement annotations
   rearrangement_list:
     type: array
     items:
-      $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Rearrangement'
+      allOf:
+        $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Rearrangement'
+        $ref: '#/definitions/rearrangement_extension_fields'
 
   # The response object /rearrangement endpoint
   rearrangement_response:

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -96,8 +96,9 @@ definitions:
         $ref: '#/definitions/facet_list'
         
   # list of rearrangement extension fields
-  rearrangement_extension_fields:  
-          adc_v_subgroup:
+  rearrangement_extension_fields:
+    allOf:
+      adc_v_subgroup:
             type: string
             description: >
                 V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
@@ -125,8 +126,8 @@ definitions:
     type: array
     items:
       allOf:
-        $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Rearrangement'
-        $ref: '#/definitions/rearrangement_extension_fields'
+        - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Rearrangement'
+        - $ref: '#/definitions/rearrangement_extension_fields'
 
   # The response object /rearrangement endpoint
   rearrangement_response:

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -96,39 +96,40 @@ definitions:
         $ref: '#/definitions/facet_list'
         
   # list of rearrangement extension fields
-  rearrangement_extension_fields:
-    type: object
-    properties:
-      adc_v_subgroup:
-        type: string
-        description: >
-          V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-          the relevant gene nomenclature should be followed (e.g., IGHV4).
-        example: IGHV4
-        x-airr:
-          nullable: true
-          adc-api-optional: false
-          adc-query_support: true
-          name: V gene subgroup
-      adc_v_gene:
-        type: string
-        description: >
-          V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-          the relevant gene nomenclature should be followed (e.g., IGHV4-59).
-        example: IGHV4-59
-        x-airr:
-          nullable: true
-          adc-api-optional: false
-          adc-query_support: true
-          name: V gene  
+  rearrangement_extension:
+    description: The extended Rearrangement object with additional query fields for the ADC.
+    allOf:
+      - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Rearrangement'
+      - type: object
+        properties:
+          adc_v_subgroup:
+            type: string
+            description: >
+              V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHV4).
+            example: IGHV4
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: V gene subgroup
+          adc_v_gene:
+            type: string
+            description: >
+              V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+            example: IGHV4-59
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: V gene
   
   # list of rearrangement annotations
   rearrangement_list:
     type: array
     items:
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Rearrangement'
-        - $ref: '#/definitions/rearrangement_extension_fields'
+      $ref: '#/definitions/rearrangement_extension'
 
   # The response object /rearrangement endpoint
   rearrangement_response:

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -265,7 +265,7 @@ definitions:
   clone_list:
     type: array
     items:
-      $ref: '#/definitions/rearrangement_extension'
+      $ref: '#/definitions/clone_extension'
 
   # The response object /clone/{clone_id} endpoint
   clone_id_response:

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -168,7 +168,28 @@ definitions:
               adc-api-optional: false
               adc-query_support: true
               name: J gene
-
+          adc_c_subgroup:
+            type: string
+            description: >
+              C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: C gene subgroup
+          adc_c_gene:
+            type: string
+            description: >
+              C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: C gene
 
   # list of rearrangement annotations
   rearrangement_list:
@@ -260,7 +281,29 @@ definitions:
               adc-api-optional: false
               adc-query_support: true
               name: J gene
-
+          adc_c_subgroup:
+            type: string
+            description: >
+              C subgroup of the C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: C gene subgroup
+          adc_c_gene:
+            type: string
+            description: >
+              C gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+              the relevant gene nomenclature should be followed (e.g., IGHG1).
+            example: IGHG1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: C gene
+              
   # list of clone annotations
   clone_list:
     type: array

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -97,29 +97,30 @@ definitions:
         
   # list of rearrangement extension fields
   rearrangement_extension_fields:
-    allOf:
+    type: object
+    properties:
       adc_v_subgroup:
-            type: string
-            description: >
-                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4).
-            example: IGHV4
-            x-airr:
-                nullable: true
-                adc-api-optional: false
-                adc-query_support: true
-                name: V gene subgroup
-        adc_v_gene:
-            type: string
-            description: >
-                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
-            example: IGHV4-59
-            x-airr:
-                nullable: true
-                adc-api-optional: false
-                adc-query_support: true
-                name: V gene  
+        type: string
+        description: >
+          V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+          the relevant gene nomenclature should be followed (e.g., IGHV4).
+        example: IGHV4
+        x-airr:
+          nullable: true
+          adc-api-optional: false
+          adc-query_support: true
+          name: V gene subgroup
+      adc_v_gene:
+        type: string
+        description: >
+          V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+          the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+        example: IGHV4-59
+        x-airr:
+          nullable: true
+          adc-api-optional: false
+          adc-query_support: true
+          name: V gene  
   
   # list of rearrangement annotations
   rearrangement_list:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2173,6 +2173,28 @@ Rearrangement:
                 set: 6
                 subset: data (processed sequence)
                 name: V gene with allele
+        adc_v_subgroup:
+            type: string
+            description: >
+                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4).
+            example: IGHV4
+            x-airr:
+                nullable: true
+                adc-api-optional: false
+                adc-query_support: true
+                name: V gene subgroup
+        adc_v_gene:
+            type: string
+            description: >
+                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
+                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
+            example: IGHV4-59
+            x-airr:
+                nullable: true
+                adc-api-optional: false
+                adc-query_support: true
+                name: V gene        
         d_call:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2172,29 +2172,7 @@ Rearrangement:
                 adc-query-support: true
                 set: 6
                 subset: data (processed sequence)
-                name: V gene with allele
-        adc_v_subgroup:
-            type: string
-            description: >
-                V subgroup of the V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4).
-            example: IGHV4
-            x-airr:
-                nullable: true
-                adc-api-optional: false
-                adc-query_support: true
-                name: V gene subgroup
-        adc_v_gene:
-            type: string
-            description: >
-                V gene. If referring to a known reference sequence in a database, such as IMGT/GENE-DB,
-                the relevant gene nomenclature should be followed (e.g., IGHV4-59).
-            example: IGHV4-59
-            x-airr:
-                nullable: true
-                adc-api-optional: false
-                adc-query_support: true
-                name: V gene        
+                name: V gene with allele      
         d_call:
             type: string
             description: >


### PR DESCRIPTION
When we closed https://github.com/airr-community/airr-standards/pull/295 we agreed that these fields should be added to the ADC API but not be part of the actual file format standard. They are a query convenience. When we closed the other issue we didn't create something to capture this need.

@schristley not sure how to do this, but I copied the mechanism you used for adc_update_date.

Lets add this to discussion at CRWG tomorrow.