### PR TITLE
Change germline definitions for consistency

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -697,15 +697,15 @@ AlleleDescription:
                 - retired
                 - withdrawn
             description: Status of record, assumed active if the field is not proesent
-        gene_subgroup:
-            type: string
-            description: Gene subgroup or clade, as (and if) identified for this species and gene
         subgroup_designation:
             type: string
-            description: Gene designation within this subgroup, if identified
+            description: Identifier of the gene subgroup or clade, as (and if) defined
+        gene_designation:
+            type: string
+            description: Gene number or other identifier, as (and if) defined
         allele_designation:
             type: string
-            description: Allele designation, if identified
+            description: Allele number or other identifier, as (and if) defined
         j_codon_frame:
             type: integer
             enum:
@@ -1022,7 +1022,7 @@ Genotype:
             items:
                 type: object
                 properties:
-                    gene_symbol:
+                    label:
                         type: string
                         description: The accepted name for this gene, taken from the GermlineSet
                         x-airr:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -697,15 +697,15 @@ AlleleDescription:
                 - retired
                 - withdrawn
             description: Status of record, assumed active if the field is not proesent
-        gene_subgroup:
-            type: string
-            description: Gene subgroup or clade, as (and if) identified for this species and gene
         subgroup_designation:
             type: string
-            description: Gene designation within this subgroup, if identified
+            description: Identifier of the gene subgroup or clade, as (and if) defined
+        gene_designation:
+            type: string
+            description: Gene number or other identifier, as (and if) defined
         allele_designation:
             type: string
-            description: Allele designation, if identified
+            description: Allele number or other identifier, as (and if) defined
         j_codon_frame:
             type: integer
             enum:
@@ -1022,7 +1022,7 @@ Genotype:
             items:
                 type: object
                 properties:
-                    gene_symbol:
+                    label:
                         type: string
                         description: The accepted name for this gene, taken from the GermlineSet
                         x-airr:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -676,18 +676,18 @@ AlleleDescription:
                 - retired
                 - withdrawn
             description: Status of record, assumed active if the field is not proesent
-        gene_subgroup:
-            type: string
-            nullable: true
-            description: Gene subgroup or clade, as (and if) identified for this species and gene
         subgroup_designation:
             type: string
             nullable: true
-            description: Gene designation within this subgroup, if identified
+            description: Identifier of the gene subgroup or clade, as (and if) defined
+        gene_designation:
+            type: string
+            nullable: true
+            description: Gene number or other identifier, as (and if) defined
         allele_designation:
             type: string
             nullable: true
-            description: Allele designation, if identified
+            description: Allele number or other identifier, as (and if) defined
         j_codon_frame:
             type: integer
             nullable: true
@@ -1024,7 +1024,7 @@ Genotype:
             items:
                 type: object
                 properties:
-                    gene_symbol:
+                    label:
                         type: string
                         nullable: false
                         description: The accepted name for this gene, taken from the GermlineSet

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -697,15 +697,15 @@ AlleleDescription:
                 - retired
                 - withdrawn
             description: Status of record, assumed active if the field is not proesent
-        gene_subgroup:
-            type: string
-            description: Gene subgroup or clade, as (and if) identified for this species and gene
         subgroup_designation:
             type: string
-            description: Gene designation within this subgroup, if identified
+            description: Identifier of the gene subgroup or clade, as (and if) defined
+        gene_designation:
+            type: string
+            description: Gene number or other identifier, as (and if) defined
         allele_designation:
             type: string
-            description: Allele designation, if identified
+            description: Allele number or other identifier, as (and if) defined
         j_codon_frame:
             type: integer
             enum:
@@ -1022,7 +1022,7 @@ Genotype:
             items:
                 type: object
                 properties:
-                    gene_symbol:
+                    label:
                         type: string
                         description: The accepted name for this gene, taken from the GermlineSet
                         x-airr:


### PR DESCRIPTION
fixes #554 
fixes #557 

this covers changes to:

subgroup_designation
gene_designation
allele_designation

and

undocumented_genes/gene_symbol to label