### PR TITLE
Germline labels

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -407,7 +407,8 @@ fields = ['Name', 'Type', 'Attributes', 'Definition']
 tables = ['Repertoire', 'Study', 'Subject', 'Diagnosis', 'Sample', 'CellProcessing', 'NucleicAcidProcessing',
           'PCRTarget', 'SequencingRun', 'RawSequenceData', 'DataProcessing',
           'Rearrangement', 'Alignment', 'Clone', 'Tree', 'Node', 'Cell',
-          'RearrangedSequence', 'GermlineSequence', 'GeneDelineationV', 'GeneDescription', 'GermlineSet']
+          'RearrangedSequence', 'UnrearrangedSequence', 'SequenceDelineationV', 'AlleleDescription', 'GermlineSet',
+          'GenotypeSet','Genotype']
 for spec in tables:
     with open(os.path.join(download_path, '%s.tsv' % spec), 'w') as f:
         writer = csv.DictWriter(f, fieldnames=fields, dialect='excel-tab', extrasaction='ignore')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -408,7 +408,7 @@ tables = ['Repertoire', 'Study', 'Subject', 'Diagnosis', 'Sample', 'CellProcessi
           'PCRTarget', 'SequencingRun', 'RawSequenceData', 'DataProcessing',
           'Rearrangement', 'Alignment', 'Clone', 'Tree', 'Node', 'Cell',
           'RearrangedSequence', 'UnrearrangedSequence', 'SequenceDelineationV', 'AlleleDescription', 'GermlineSet',
-          'GenotypeSet','Genotype']
+          'GenotypeSet', 'Genotype', 'MHCGenotypeSet', 'MHCGenotype']
 for spec in tables:
     with open(os.path.join(download_path, '%s.tsv' % spec), 'w') as f:
         writer = csv.DictWriter(f, fieldnames=fields, dialect='excel-tab', extrasaction='ignore')

--- a/docs/datarep/germline.rst
+++ b/docs/datarep/germline.rst
@@ -77,7 +77,7 @@ locus, and to be directly usable by annotation tools and other processing softwa
 
 The file must contain YAML or JSON representation of a single ``GermlineSet`` object, including the associated ``AlleleDescription`` objects. It may optionally
 include other associated objects: ``SequenceDelineationV``, ``RearrangedSequence``, ``UnrearrangedSequence``, ``Acknowledgement``. These should all be embedded into the
-overall ``GermlineSet`` as specified in the schema.
+overall ``GermlineSet`` as specified in the schema. The overall structure must match that defined for AIRR Data Files in the ``DataFile`` schema. 
 
 .. _GermlineSetFields:
 

--- a/docs/datarep/germline.rst
+++ b/docs/datarep/germline.rst
@@ -34,24 +34,26 @@ For V-genes, an IMGT-gapped sequence (i.e.,. a sequence delineated in accordance
 ``AlleleDescription``. Other delineations, such as  `Chothia <http://www.bioinf.org.uk/abs/info.html#chothianum>`_ and 
 `Kabat <http://www.bioinf.org.uk/abs/info.html#kabatnum>`_, can be provided via linked ``SequenceDelineationV`` objects.
 A ``GermlineSet`` brings together multiple ``AlleleDescriptions`` from the same locus to form a curated set. The schema assumes that germline 
-sets will be published by multiple repositories. A germline set may be uniquely referenced by means of the ``germline_set_ref`` 
+sets will be published by multiple repositories. A germline set may be uniquely referenced by means of the ``germline_set_ref``: 
 this is a composite field containing the repository id, germline set label, and version.
 
 Gene and Allele Naming
 ----------------------
 
-The International Union of Immunological Societies allocates gene symbols for receptor genes. ``AlleleDescription`` contains a ``label`` 
-field, but it is optional, recognising that a symbol may not have been assigned. Gene symbols are long-lasting, but the underlying 
-sequence may be revised over time. ``AlleleDescription`` contains a mandatory ``coding_sequence_identifier``, which will be updated should the 
-sequence change. It is anticipated that publishers of gene sets will provide mechanisms to issue these identifiers, and to allow 
-researchers to review change history of ``AlleleDescriptions`` and ``GermlineSets``. In the interests of consistency and transparency, when 
-referring to a gene or allele, the ``label`` should be used wherever possible, however ``coding_sequence_identifier`` provides a fallback 
-where a gene symbol has not been assigned.
+``AlleleDescription`` contains a ``label`` field, which should contain the accepted name for the field, as determined by the authors/curators 
+of the record. The International Union of Immunological Societies allocates gene symbols for receptor genes, and, if a gene symbol has been 
+allocated, this should be used as the label.  Where a gene symbol has not been allocated (for example, because the gene or allele has only 
+recently been discovered, or because the available evidence does not meet IUIS standards, a 'tempporary label' should be used.  It is anticipated 
+that publishers of gene sets will provide mechanisms to issue these temporary labels, and to allow researchers to review change history of 
+``AlleleDescriptions`` and ``GermlineSets``. To provide consistency across research groups, the  
+`Germline Database Working Group of the AIRR Community <https://www.antibodysociety.org/the-airr-community/airr-working-groups/germline_database/>`_ is 
+developing a `community-wide approach <https://github.com/williamdlees/IgLabel>`_ to the allocation of temporary labels.
 
 Genotypes
 ---------
 
-A ``GenotypeSet`` describes the specific alleles found in an individual, and also identifies genes that are not found (deleted). 
+A ``GenotypeSet`` describes the specific alleles found in an individual, and also identifies genes that are not found (this could be either 
+because they are not present in the chromosomal locus, or brcause they are not expressed or expressed only at low levels). 
 Depending on the data available and the inference method used, genotypes may contain haplotyping information, which may be full, or partial. 
 As an example of partial haplotyping, the genotype may have been determined from genomic sequencing in which the sequence of the locus was 
 assembled into contigs, but could not be fully assembled. In this case the co-location of alleles in each contig has been established, but 

--- a/docs/datarep/germline.rst
+++ b/docs/datarep/germline.rst
@@ -60,7 +60,7 @@ assembled into contigs, but could not be fully assembled. In this case the co-lo
 the co-location across the entire locus can not be. Co-location is therefore indicated by means of the ``phasing`` parameter, which in this 
 case would be assigned a different value for alleles on each contig. 
 
-Correspondingly, ``MHCGenotype`` amd ``MHCGenotypeSet`` describe the MHC alleles found in an subject.
+Correspondingly, ``MHCGenotype`` amd ``MHCGenotypeSet`` describe the MHC alleles found in a subject.
 
 File Format Specification
 -------------------------

--- a/docs/datarep/germline.rst
+++ b/docs/datarep/germline.rst
@@ -34,14 +34,14 @@ For V-genes, an IMGT-gapped sequence (i.e.,. a sequence delineated in accordance
 ``AlleleDescription``. Other delineations, such as  `Chothia <http://www.bioinf.org.uk/abs/info.html#chothianum>`_ and 
 `Kabat <http://www.bioinf.org.uk/abs/info.html#kabatnum>`_, can be provided via linked ``SequenceDelineationV`` objects.
 A ``GermlineSet`` brings together multiple ``AlleleDescriptions`` from the same locus to form a curated set. The schema assumes that germline 
-sets will be published by multiple repositories. A germline set may be uniquely referenced by means of the ``germline_set_ref``: 
-this is a composite field containing the repository id, germline set label, and version.
+sets will be published by multiple repositories. A germline set may be uniquely referenced by means of the ``germline_set_ref``, which
+is a composite field containing the repository id, germline set label, and version.
 
 Gene and Allele Naming
 ----------------------
 
 ``AlleleDescription`` contains a ``label`` field, which should contain the accepted name for the field, as determined by the authors/curators 
-of the record. The International Union of Immunological Societies allocates gene symbols for receptor genes, and, if a gene symbol has been 
+of the record. The `Nomenclature Committee <https://iuis.org/committees/nom/>`_ of the International Union of Immunological Societies (IUIS) allocates gene symbols for receptor genes, and, if a gene symbol has been 
 allocated, this should be used as the label.  Where a gene symbol has not been allocated (for example, because the gene or allele has only 
 recently been discovered, or because the available evidence does not meet IUIS standards, a 'temporary label' should be used.  It is anticipated 
 that publishers of gene sets will provide mechanisms to issue these temporary labels, and to allow researchers to review change history of 
@@ -72,12 +72,29 @@ extension ``.yaml``, ``.yml``, or ``.json``.
 Germline Set File Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Germline Set file has a standardised structure. It is intended to contan all information necessary to annotate receptor sequences derived from a single germline
+The Germline Set file has a standardised structure that is utilized by all top-level AIRR Schema Objects and defined by
+the ``DataFile`` schema. It is intended to contan all information necessary to annotate receptor sequences derived from a single germline
 locus, and to be directly usable by annotation tools and other processing software.
 
-The file must contain YAML or JSON representation of a single ``GermlineSet`` object, including the associated ``AlleleDescription`` objects. It may optionally
+The file must contain YAML or JSON representation of one or more ``GermlineSet`` objects, including the associated ``AlleleDescription`` objects. It may optionally
 include other associated objects: ``SequenceDelineationV``, ``RearrangedSequence``, ``UnrearrangedSequence``, ``Acknowledgement``. These should all be embedded into the
-overall ``GermlineSet`` as specified in the schema. The overall structure must match that defined for AIRR Data Files in the ``DataFile`` schema. 
+overall ``GermlineSet`` as specified in the schema.
+
++ The file as a whole is considered a dictionary (key/value pair) structure with the keys ``Info``, ``GermlineSet``, and ``AlleleDescription``.
+
++ The file can (optionally) contain an ``Info`` object, at the beginning of the file, based upon the ``Info`` schema in the OpenAPI specification. If provided, ``version`` in ``Info`` should reference the version of the AIRR schema for the file.
+
++ The file should correspond to a list of ``GermlineSet`` objects, using ``GermlineSet`` as the key to the list.
+
++ The file should correspond to a list of ``AlleleDescription`` objects, using ``AlleleDescription`` as the key to the list.
+
++ Each ``AlleleDescription`` object should contain a top-level key/value pair for ``allele_description_id`` that uniquely identifies the allele description object in the file.
+
++ Each ``GermlineSet`` object should contain a top-level key/value pair for ``germline_set_id`` that uniquely identifies the germline set object in the file.
+
++ Some fields require the use of a particular ontology or controlled vocabulary.
+
++ The structure is the same regardless of whether the data is stored in a file or retrieved from a data repository. For example, The :ref:`ADC API <DataCommonsAPI>` will return a properly structured JSON object that can be saved to a file and used directly without modification.
 
 .. _GermlineSetFields:
 

--- a/docs/datarep/germline.rst
+++ b/docs/datarep/germline.rst
@@ -43,7 +43,7 @@ Gene and Allele Naming
 ``AlleleDescription`` contains a ``label`` field, which should contain the accepted name for the field, as determined by the authors/curators 
 of the record. The International Union of Immunological Societies allocates gene symbols for receptor genes, and, if a gene symbol has been 
 allocated, this should be used as the label.  Where a gene symbol has not been allocated (for example, because the gene or allele has only 
-recently been discovered, or because the available evidence does not meet IUIS standards, a 'tempporary label' should be used.  It is anticipated 
+recently been discovered, or because the available evidence does not meet IUIS standards, a 'temporary label' should be used.  It is anticipated 
 that publishers of gene sets will provide mechanisms to issue these temporary labels, and to allow researchers to review change history of 
 ``AlleleDescriptions`` and ``GermlineSets``. To provide consistency across research groups, the  
 `Germline Database Working Group of the AIRR Community <https://www.antibodysociety.org/the-airr-community/airr-working-groups/germline_database/>`_ is 
@@ -52,13 +52,15 @@ developing a `community-wide approach <https://github.com/williamdlees/IgLabel>`
 Genotypes
 ---------
 
-A ``GenotypeSet`` describes the specific alleles found in an individual, and also identifies genes that are not found (this could be either 
+A ``GenotypeSet`` describes the specific receptor alleles found in a subject, and also identifies genes that are not found (this could be either 
 because they are not present in the chromosomal locus, or brcause they are not expressed or expressed only at low levels). 
 Depending on the data available and the inference method used, genotypes may contain haplotyping information, which may be full, or partial. 
 As an example of partial haplotyping, the genotype may have been determined from genomic sequencing in which the sequence of the locus was 
 assembled into contigs, but could not be fully assembled. In this case the co-location of alleles in each contig has been established, but 
 the co-location across the entire locus can not be. Co-location is therefore indicated by means of the ``phasing`` parameter, which in this 
 case would be assigned a different value for alleles on each contig. 
+
+Correspondingly, ``MHCGenotype`` amd ``MHCGenotypeSet`` describe the MHC alleles found in an subject.
 
 File Format Specification
 -------------------------
@@ -67,10 +69,15 @@ Files are YAML/JSON with a structure defined below. Files should be
 encoded as UTF-8. Identifiers are case-sensitive. Files should have the
 extension ``.yaml``, ``.yml``, or ``.json``.
 
-File Structure
-~~~~~~~~~~~~~~
+Germline Set File Structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The file structure has not been specified yet.
+The Germline Set file has a standardised structure. It is intended to contan all information necessary to annotate receptor sequences derived from a single germline
+locus, and to be directly usable by annotation tools and other processing software.
+
+The file must contain YAML or JSON representation of a single ``GermlineSet`` object, including the associated ``AlleleDescription`` objects. It may optionally
+include other associated objects: ``SequenceDelineationV``, ``RearrangedSequence``, ``UnrearrangedSequence``, ``Acknowledgement``. These should all be embedded into the
+overall ``GermlineSet`` as specified in the schema.
 
 .. _GermlineSetFields:
 

--- a/docs/datarep/germline.rst
+++ b/docs/datarep/germline.rst
@@ -16,42 +16,42 @@ Receptor Germline Schema
 ------------------------
 
 The receptor germline schema defines the data elements necessary to describe one or more receptor germline genes, together 
-with supporting evidence. The fundamental object is the ``GeneDescription``, which describes a single gene or allele, containing 
+with supporting evidence. The fundamental object is the ``AlleleDescription``, which describes a single gene or allele, containing 
 the necessary details for the annotation of a rearranged sequence such as the location of CDRs (in the case of a V-gene) and 
-framing information (in the case of a J-gene). ``GeneDescription`` also contains fields to delineate RSS, and the leader regions 
+framing information (in the case of a J-gene). ``AlleleDescription`` also contains fields to delineate RSS, and the leader regions 
 of V-genes, should those be covered by the sequence provided.
 
-Evidence supporting the gene or allele can be provided in linked ``GermlineSequence`` and ``RearrangedSequence`` objects. Information 
+Evidence supporting the gene or allele can be provided in linked ``UnrearrangedSequence`` and ``RearrangedSequence`` objects. Information 
 represented in these objects will typically be stored in a repository: either an INSDC repository such as Genbank or SRA, or 
 a lower-tier repository such as OGRDB. Please note that the key distinction between these object types is whether the V(D)J 
 genes have rearranged, rather than the origin of the material, as mature B and T cells carry rearranged sequences in chromosomal 
-DNA. It is most likely that supporting sequences will be GermlineSequences, i.e. prior to rearrangement. In the case of a 
-germline inference from a repertoire, the inferred germline sequence should be provided as a ``GermlineSequence``, if the evidence 
+DNA. It is most likely that supporting sequences will be ``UnrearrangedSequences``, i.e. prior to rearrangement. In the case of a 
+germline inference from a repertoire, the inferred germline sequence should be provided as a ``RearrangedSequence``, if the evidence 
 has been deposited in a repository.
 
 For V-genes, an IMGT-gapped sequence (i.e.,. a sequence delineated in accordance with the 
 `IMGT numbering scheme <http://www.imgt.org/IMGTindex/numbering.php>`_)  is provided in 
-``GeneDescription``. Other delineations, such as  `Chothia <http://www.bioinf.org.uk/abs/info.html#chothianum>`_ and 
-`Kabat <http://www.bioinf.org.uk/abs/info.html#kabatnum>`_, can be provided via linked ``GeneDelineationV`` objects.
-A ``GermlineSet`` brings together multiple ``GeneDescriptions`` from the same locus to form a curated set. The schema assumes that germline 
-sets will be published by multiple repositories. A germline set may be uniquely referenced by means of the ``germline_set_ref:`` 
+``AlleleDescription``. Other delineations, such as  `Chothia <http://www.bioinf.org.uk/abs/info.html#chothianum>`_ and 
+`Kabat <http://www.bioinf.org.uk/abs/info.html#kabatnum>`_, can be provided via linked ``SequenceDelineationV`` objects.
+A ``GermlineSet`` brings together multiple ``AlleleDescriptions`` from the same locus to form a curated set. The schema assumes that germline 
+sets will be published by multiple repositories. A germline set may be uniquely referenced by means of the ``germline_set_ref`` 
 this is a composite field containing the repository id, germline set label, and version.
 
 Gene and Allele Naming
 ----------------------
 
-The International Union of Immunological Societies allocates gene symbols for receptor genes. GeneDescription contains a gene_symbol 
+The International Union of Immunological Societies allocates gene symbols for receptor genes. ``AlleleDescription`` contains a ``label`` 
 field, but it is optional, recognising that a symbol may not have been assigned. Gene symbols are long-lasting, but the underlying 
-sequence may be revised over time. GeneDescription contains a mandatory coding_sequence_identifier, which will be updated should the 
+sequence may be revised over time. ``AlleleDescription`` contains a mandatory ``coding_sequence_identifier``, which will be updated should the 
 sequence change. It is anticipated that publishers of gene sets will provide mechanisms to issue these identifiers, and to allow 
-researchers to review change history of GeneDescriptions and GermlineSets. In the interests of consistency and transparency, when 
-referring to a gene or allele, the gene_symbol should be used wherever possible, however coding_sequence_identifier provides a fallback 
+researchers to review change history of ``AlleleDescriptions`` and ``GermlineSets``. In the interests of consistency and transparency, when 
+referring to a gene or allele, the ``label`` should be used wherever possible, however ``coding_sequence_identifier`` provides a fallback 
 where a gene symbol has not been assigned.
 
 Genotypes
 ---------
 
-A ``ReceptorGenotype`` describes the specific alleles found in an individual, and also identifies genes that are not found (deleted). 
+A ``GenotypeSet`` describes the specific alleles found in an individual, and also identifies genes that are not found (deleted). 
 Depending on the data available and the inference method used, genotypes may contain haplotyping information, which may be full, or partial. 
 As an example of partial haplotyping, the genotype may have been determined from genomic sequencing in which the sequence of the locus was 
 assembled into contigs, but could not be fully assembled. In this case the co-location of alleles in each contig has been established, but 
@@ -61,7 +61,14 @@ case would be assigned a different value for alleles on each contig.
 File Format Specification
 -------------------------
 
-The file format has not been specified yet.
+Files are YAML/JSON with a structure defined below. Files should be
+encoded as UTF-8. Identifiers are case-sensitive. Files should have the
+extension ``.yaml``, ``.yml``, or ``.json``.
+
+File Structure
+~~~~~~~~~~~~~~
+
+The file structure has not been specified yet.
 
 .. _GermlineSetFields:
 
@@ -85,12 +92,12 @@ GermlineSet Fields
       - {{ field.Definition | trim }}
     {%- endfor %}
 
-.. _GeneDescriptionFields:
+.. _AlleleDescriptionFields:
 
-GeneDescription Fields
+AlleleDescription Fields
 -----------------------------
 
-:download:`Download as TSV <../_downloads/GeneDescription.tsv>`
+:download:`Download as TSV <../_downloads/AlleleDescription.tsv>`
 
 .. list-table::
     :widths: 20, 15, 15, 50
@@ -100,7 +107,7 @@ GeneDescription Fields
       - Type
       - Attributes
       - Definition
-    {%- for field in GeneDescription_schema %}
+    {%- for field in AlleleDescription_schema %}
     * - ``{{ field.Name }}``
       - {{ field.Type }}
       - {{ field.Attributes }}
@@ -129,12 +136,12 @@ RearrangedSequence Fields
       - {{ field.Definition | trim }}
     {%- endfor %}
 
-.. _GermlineSequenceFields:
+.. _UnrearrangedSequenceFields:
 
-GermlineSequence Fields
+UnrearrangedSequence Fields
 -----------------------------
 
-:download:`Download as TSV <../_downloads/GermlineSequence.tsv>`
+:download:`Download as TSV <../_downloads/UnrearrangedSequence.tsv>`
 
 .. list-table::
     :widths: 20, 15, 15, 50
@@ -144,19 +151,19 @@ GermlineSequence Fields
       - Type
       - Attributes
       - Definition
-    {%- for field in GermlineSequence_schema %}
+    {%- for field in UnrearrangedSequence_schema %}
     * - ``{{ field.Name }}``
       - {{ field.Type }}
       - {{ field.Attributes }}
       - {{ field.Definition | trim }}
     {%- endfor %}
 
-.. _GeneDelineationVFields:
+.. _SequenceDelineationVFields:
 
-GeneDelineationV Fields
+SequenceDelineationV Fields
 -----------------------------
 
-:download:`Download as TSV <../_downloads/GeneDelineationV.tsv>`
+:download:`Download as TSV <../_downloads/SequenceDelineationV.tsv>`
 
 .. list-table::
     :widths: 20, 15, 15, 50
@@ -166,19 +173,19 @@ GeneDelineationV Fields
       - Type
       - Attributes
       - Definition
-    {%- for field in GeneDelineationV_schema %}
+    {%- for field in SequenceDelineationV_schema %}
     * - ``{{ field.Name }}``
       - {{ field.Type }}
       - {{ field.Attributes }}
       - {{ field.Definition | trim }}
     {%- endfor %}
 
-.. _ReceptorGenotypeFields:
+.. _GenotypeSetFields:
 
-ReceptorGenotype Fields
+GenotypeSet Fields
 -----------------------------
 
-:download:`Download as TSV <../_downloads/ReceptorGenotype.tsv>`
+:download:`Download as TSV <../_downloads/GenotypeSet.tsv>`
 
 .. list-table::
     :widths: 20, 15, 15, 50
@@ -188,7 +195,51 @@ ReceptorGenotype Fields
       - Type
       - Attributes
       - Definition
-    {%- for field in ReceptorGenotype_schema %}
+    {%- for field in GenotypeSet_schema %}
+    * - ``{{ field.Name }}``
+      - {{ field.Type }}
+      - {{ field.Attributes }}
+      - {{ field.Definition | trim }}
+    {%- endfor %}
+
+.. _GenotypeFields:
+
+Genotype Fields
+-----------------------------
+
+:download:`Download as TSV <../_downloads/Genotype.tsv>`
+
+.. list-table::
+    :widths: 20, 15, 15, 50
+    :header-rows: 1
+
+    * - Name
+      - Type
+      - Attributes
+      - Definition
+    {%- for field in Genotype_schema %}
+    * - ``{{ field.Name }}``
+      - {{ field.Type }}
+      - {{ field.Attributes }}
+      - {{ field.Definition | trim }}
+    {%- endfor %}
+
+.. _MHCGenotypeSetFields:
+
+MHCGenotypeSet Fields
+-----------------------------
+
+:download:`Download as TSV <../_downloads/MHCGenotypeSet.tsv>`
+
+.. list-table::
+    :widths: 20, 15, 15, 50
+    :header-rows: 1
+
+    * - Name
+      - Type
+      - Attributes
+      - Definition
+    {%- for field in MHCGenotypeSet_schema %}
     * - ``{{ field.Name }}``
       - {{ field.Type }}
       - {{ field.Attributes }}

--- a/docs/datarep/germline.rst
+++ b/docs/datarep/germline.rst
@@ -53,7 +53,7 @@ Genotypes
 ---------
 
 A ``GenotypeSet`` describes the specific receptor alleles found in a subject, and also identifies genes that are not found (this could be either 
-because they are not present in the chromosomal locus, or brcause they are not expressed or expressed only at low levels). 
+because they are not present in the chromosomal locus, or because they are not expressed or expressed only at low levels).
 Depending on the data available and the inference method used, genotypes may contain haplotyping information, which may be full, or partial. 
 As an example of partial haplotyping, the genotype may have been determined from genomic sequencing in which the sequence of the locus was 
 assembled into contigs, but could not be fully assembled. In this case the co-location of alleles in each contig has been established, but 

--- a/docs/datarep/overview.rst
+++ b/docs/datarep/overview.rst
@@ -33,7 +33,7 @@ AIRR Data Model
 
 The MiAIRR standard defines the minimal information for submission and
 publication of AIRR-seq datasets. The standard defines a set of data
-elements for this information and organizes them into six high-level
+elements for this information and organizes them into seven high-level
 sets.
 
 + Study, Subject and Diagnosis
@@ -47,6 +47,8 @@ sets.
 + Data Processing
 
 + Processed Sequences with Annotations
+
++ Receptor Germline Genes and Germline Sets
 
 However beyond these sets, MiAIRR does not define any structure, data
 model or relationship between the data elements. This provides
@@ -85,6 +87,12 @@ Here are the primary schema objects of the AIRR Data Model:
       - Composite object that combines the schema objects ``Study``, ``Subject``, ``Diagnosis``, ``Sample``, ``CellProcessing``, ``NucleicAcidProcessing``, ``SequencingRun``, and ``DataProcessing``. Each ``Repertoire`` has a unique identifier ``repertoire_id`` for linking with other data files, e.g. ``Rearrangements``. ``Repertoires`` have their own schema and file format described :ref:`here <RepertoireSchema>`.
     * - ``Rearrangments``
       - Annotated sequences describing adaptive immune receptor chains. ``Rearrangements`` have their own schema and file format described :ref:`here <RearrangementSchema>`.
+    * - ``GermlineSet``
+      - Lists the receptor germline sequences that have been identified for a single locus within a particular species or sub-species, together with supporting evidence and additional metadata to assist with sequence annotation. Brings togteher the subsidiary objects ``AlleleDescription``, ``SequenceDelineationV``, ``RearrangedSequence``, ``UnrearrangedSequence``, ``Acknowledgement``.
+    * - ``GenotypeSet``
+      - Lists the receptor germline sequences that have been identified within a single subject, including both those that are listed within ``GermlineSets`` and those that have not been so listed. References the subsidiary object ``Genotype``, which covers a single locus.
+ 
+  
 
 Relationship between Schema Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/datarep/overview.rst
+++ b/docs/datarep/overview.rst
@@ -33,7 +33,7 @@ AIRR Data Model
 
 The MiAIRR standard defines the minimal information for submission and
 publication of AIRR-seq datasets. The standard defines a set of data
-elements for this information and organizes them into seven high-level
+elements for this information and organizes them into six high-level
 sets.
 
 + Study, Subject and Diagnosis
@@ -47,8 +47,6 @@ sets.
 + Data Processing
 
 + Processed Sequences with Annotations
-
-+ Receptor Germline Genes and Germline Sets
 
 However beyond these sets, MiAIRR does not define any structure, data
 model or relationship between the data elements. This provides

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -679,7 +679,7 @@ AlleleDescription:
         species_subgroup:
             type: string
             description: Race, strain or other species subgroup to which this subject belongs
-            example: BALB/C
+            example: BALB/c
         species_subgroup_type:
             type: string
             enum:
@@ -695,7 +695,7 @@ AlleleDescription:
                 - draft
                 - retired
                 - withdrawn
-            description: Status of record, assumed active if the field is not proesent
+            description: Status of record, assumed active if the field is not present
         subgroup_designation:
             type: string
             description: Identifier of the gene subgroup or clade, as (and if) defined
@@ -765,7 +765,7 @@ AlleleDescription:
             description: End co-ordinate (in the sequence field) of J recombination site (J-genes only)
         j_donor_splice:
             type: integer
-            description: Co-ordinate (in the sequence field) of the 3' splice donor site (J-genes only)
+            description: Co-ordinate (in the sequence field) of the final 3' nucleotide of the J-REGION (J-genes only)
         v_gene_delineations:
             type: array
             items:
@@ -878,7 +878,7 @@ GermlineSet:
         species_subgroup:
             type: string
             description: Race, strain or other species subgroup to which this subject belongs
-            example: BALB/C
+            example: BALB/c
         species_subgroup_type:
             type: string
             enum:

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -697,15 +697,15 @@ AlleleDescription:
                 - retired
                 - withdrawn
             description: Status of record, assumed active if the field is not proesent
-        gene_subgroup:
-            type: string
-            description: Gene subgroup or clade, as (and if) identified for this species and gene
         subgroup_designation:
             type: string
-            description: Gene designation within this subgroup, if identified
+            description: Identifier of the gene subgroup or clade, as (and if) defined
+        gene_designation:
+            type: string
+            description: Gene number or other identifier, as (and if) defined
         allele_designation:
             type: string
-            description: Allele designation, if identified
+            description: Allele number or other identifier, as (and if) defined
         j_codon_frame:
             type: integer
             enum:
@@ -1022,7 +1022,7 @@ Genotype:
             items:
                 type: object
                 properties:
-                    gene_symbol:
+                    label:
                         type: string
                         description: The accepted name for this gene, taken from the GermlineSet
                         x-airr:

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -570,7 +570,6 @@ AlleleDescription:
         - release_description
         - sequence
         - coding_sequence
-        - coding_sequence_identifier
         - locus
         - sequence_type
         - functional
@@ -974,12 +973,7 @@ Genotype:
                 properties:
                     label:
                         type: string
-                        description: The accepted name for this allele, if any, taken from the GermlineSet
-                        x-airr:
-                            nullable: false
-                    coding_sequence_identifier:
-                        type: string
-                        description: Unique identifier of the coding sequence, as allocated by an identified repository
+                        description: The accepted name for this allele, taken from the GermlineSet
                         x-airr:
                             nullable: false
                     germline_set_ref:

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -614,7 +614,7 @@ AlleleDescription:
                 nullable: false
         label:
             type: string
-            description: The accepted name for this gene or allele, if any
+            description: The accepted name for this gene or allele
             example: IGHV1-69*01
         sequence:
             type: string

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -679,7 +679,7 @@ AlleleDescription:
         species_subgroup:
             type: string
             description: Race, strain or other species subgroup to which this subject belongs
-            example: BALB/C
+            example: BALB/c
         species_subgroup_type:
             type: string
             enum:
@@ -695,7 +695,7 @@ AlleleDescription:
                 - draft
                 - retired
                 - withdrawn
-            description: Status of record, assumed active if the field is not proesent
+            description: Status of record, assumed active if the field is not present
         subgroup_designation:
             type: string
             description: Identifier of the gene subgroup or clade, as (and if) defined
@@ -765,7 +765,7 @@ AlleleDescription:
             description: End co-ordinate (in the sequence field) of J recombination site (J-genes only)
         j_donor_splice:
             type: integer
-            description: Co-ordinate (in the sequence field) of the 3' splice donor site (J-genes only)
+            description: Co-ordinate (in the sequence field) of the final 3' nucleotide of the J-REGION (J-genes only)
         v_gene_delineations:
             type: array
             items:
@@ -878,7 +878,7 @@ GermlineSet:
         species_subgroup:
             type: string
             description: Race, strain or other species subgroup to which this subject belongs
-            example: BALB/C
+            example: BALB/c
         species_subgroup_type:
             type: string
             enum:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -697,15 +697,15 @@ AlleleDescription:
                 - retired
                 - withdrawn
             description: Status of record, assumed active if the field is not proesent
-        gene_subgroup:
-            type: string
-            description: Gene subgroup or clade, as (and if) identified for this species and gene
         subgroup_designation:
             type: string
-            description: Gene designation within this subgroup, if identified
+            description: Identifier of the gene subgroup or clade, as (and if) defined
+        gene_designation:
+            type: string
+            description: Gene number or other identifier, as (and if) defined
         allele_designation:
             type: string
-            description: Allele designation, if identified
+            description: Allele number or other identifier, as (and if) defined
         j_codon_frame:
             type: integer
             enum:
@@ -1022,7 +1022,7 @@ Genotype:
             items:
                 type: object
                 properties:
-                    gene_symbol:
+                    label:
                         type: string
                         description: The accepted name for this gene, taken from the GermlineSet
                         x-airr:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -570,7 +570,6 @@ AlleleDescription:
         - release_description
         - sequence
         - coding_sequence
-        - coding_sequence_identifier
         - locus
         - sequence_type
         - functional
@@ -974,12 +973,7 @@ Genotype:
                 properties:
                     label:
                         type: string
-                        description: The accepted name for this allele, if any, taken from the GermlineSet
-                        x-airr:
-                            nullable: false
-                    coding_sequence_identifier:
-                        type: string
-                        description: Unique identifier of the coding sequence, as allocated by an identified repository
+                        description: The accepted name for this allele, taken from the GermlineSet
                         x-airr:
                             nullable: false
                     germline_set_ref:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -614,7 +614,7 @@ AlleleDescription:
                 nullable: false
         label:
             type: string
-            description: The accepted name for this gene or allele, if any
+            description: The accepted name for this gene or allele
             example: IGHV1-69*01
         sequence:
             type: string

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -555,7 +555,6 @@ AlleleDescription:
         - release_description
         - sequence
         - coding_sequence
-        - coding_sequence_identifier
         - locus
         - sequence_type
         - functional
@@ -980,11 +979,7 @@ Genotype:
                     label:
                         type: string
                         nullable: false
-                        description: The accepted name for this allele, if any, taken from the GermlineSet
-                    coding_sequence_identifier:
-                        type: string
-                        nullable: false
-                        description: Unique identifier of the coding sequence, as allocated by an identified repository
+                        description: The accepted name for this allele, taken from the GermlineSet
                     germline_set_ref:
                         type: string
                         nullable: false

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -656,7 +656,7 @@ AlleleDescription:
             type: string
             nullable: true
             description: Race, strain or other species subgroup to which this subject belongs
-            example: BALB/C
+            example: BALB/c
         species_subgroup_type:
             type: string
             nullable: true
@@ -674,7 +674,7 @@ AlleleDescription:
                 - draft
                 - retired
                 - withdrawn
-            description: Status of record, assumed active if the field is not proesent
+            description: Status of record, assumed active if the field is not present
         subgroup_designation:
             type: string
             nullable: true
@@ -879,7 +879,7 @@ GermlineSet:
             type: string
             nullable: true
             description: Race, strain or other species subgroup to which this subject belongs
-            example: BALB/C
+            example: BALB/c
         species_subgroup_type:
             type: string
             nullable: true
@@ -916,7 +916,7 @@ GermlineSet:
 # Genotype schema
 #
 
-# GenotypeSet lists the  Genotypes (describing different loci) inferred for this subject
+# GenotypeSet lists the Genotypes (describing different loci) inferred for this subject
 
 GenotypeSet:
     discriminator:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -676,18 +676,18 @@ AlleleDescription:
                 - retired
                 - withdrawn
             description: Status of record, assumed active if the field is not proesent
-        gene_subgroup:
-            type: string
-            nullable: true
-            description: Gene subgroup or clade, as (and if) identified for this species and gene
         subgroup_designation:
             type: string
             nullable: true
-            description: Gene designation within this subgroup, if identified
+            description: Identifier of the gene subgroup or clade, as (and if) defined
+        gene_designation:
+            type: string
+            nullable: true
+            description: Gene number or other identifier, as (and if) defined
         allele_designation:
             type: string
             nullable: true
-            description: Allele designation, if identified
+            description: Allele number or other identifier, as (and if) defined
         j_codon_frame:
             type: integer
             nullable: true
@@ -1024,7 +1024,7 @@ Genotype:
             items:
                 type: object
                 properties:
-                    gene_symbol:
+                    label:
                         type: string
                         nullable: false
                         description: The accepted name for this gene, taken from the GermlineSet

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -766,7 +766,7 @@ AlleleDescription:
         j_donor_splice:
             type: integer
             nullable: true
-            description: Co-ordinate (in the sequence field) of the 3' splice donor site (J-genes only)
+            description: Co-ordinate (in the sequence field) of the final 3' nucleotide of the J-REGION (J-genes only)
         v_gene_delineations:
             type: array
             nullable: true

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -595,7 +595,7 @@ AlleleDescription:
         label:
             type: string
             nullable: true
-            description: The accepted name for this gene or allele, if any
+            description: The accepted name for this gene or allele
             example: IGHV1-69*01
         sequence:
             type: string

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -697,15 +697,15 @@ AlleleDescription:
                 - retired
                 - withdrawn
             description: Status of record, assumed active if the field is not proesent
-        gene_subgroup:
-            type: string
-            description: Gene subgroup or clade, as (and if) identified for this species and gene
         subgroup_designation:
             type: string
-            description: Gene designation within this subgroup, if identified
+            description: Identifier of the gene subgroup or clade, as (and if) defined
+        gene_designation:
+            type: string
+            description: Gene number or other identifier, as (and if) defined
         allele_designation:
             type: string
-            description: Allele designation, if identified
+            description: Allele number or other identifier, as (and if) defined
         j_codon_frame:
             type: integer
             enum:
@@ -1022,7 +1022,7 @@ Genotype:
             items:
                 type: object
                 properties:
-                    gene_symbol:
+                    label:
                         type: string
                         description: The accepted name for this gene, taken from the GermlineSet
                         x-airr:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -570,7 +570,6 @@ AlleleDescription:
         - release_description
         - sequence
         - coding_sequence
-        - coding_sequence_identifier
         - locus
         - sequence_type
         - functional
@@ -974,12 +973,7 @@ Genotype:
                 properties:
                     label:
                         type: string
-                        description: The accepted name for this allele, if any, taken from the GermlineSet
-                        x-airr:
-                            nullable: false
-                    coding_sequence_identifier:
-                        type: string
-                        description: Unique identifier of the coding sequence, as allocated by an identified repository
+                        description: The accepted name for this allele, taken from the GermlineSet
                         x-airr:
                             nullable: false
                     germline_set_ref:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -556,7 +556,7 @@ SequenceDelineationV:
               type: string
             description: one string for each codon in the fields v_start to cdr3_start indicating the label of that codon according to the numbering of the delineation scheme
 
-# The Gene Description
+# Description of a putative or confirmed Ig receptor gene/allele
 AlleleDescription:
     discriminator: AIRR
     description: Details of a putative or confirmed Ig receptor gene/allele inferred from one or more observations
@@ -679,7 +679,7 @@ AlleleDescription:
         species_subgroup:
             type: string
             description: Race, strain or other species subgroup to which this subject belongs
-            example: BALB/C
+            example: BALB/c
         species_subgroup_type:
             type: string
             enum:
@@ -695,7 +695,7 @@ AlleleDescription:
                 - draft
                 - retired
                 - withdrawn
-            description: Status of record, assumed active if the field is not proesent
+            description: Status of record, assumed active if the field is not present
         subgroup_designation:
             type: string
             description: Identifier of the gene subgroup or clade, as (and if) defined
@@ -765,7 +765,7 @@ AlleleDescription:
             description: End co-ordinate (in the sequence field) of J recombination site (J-genes only)
         j_donor_splice:
             type: integer
-            description: Co-ordinate (in the sequence field) of the 3' splice donor site (J-genes only)
+            description: Co-ordinate (in the sequence field) of the final 3' nucleotide of the J-REGION (J-genes only)
         v_gene_delineations:
             type: array
             items:
@@ -878,7 +878,7 @@ GermlineSet:
         species_subgroup:
             type: string
             description: Race, strain or other species subgroup to which this subject belongs
-            example: BALB/C
+            example: BALB/c
         species_subgroup_type:
             type: string
             enum:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -614,7 +614,7 @@ AlleleDescription:
                 nullable: false
         label:
             type: string
-            description: The accepted name for this gene or allele, if any
+            description: The accepted name for this gene or allele
             example: IGHV1-69*01
         sequence:
             type: string


### PR DESCRIPTION
closes #571 

Add a description of the file structure to the Germline Sets section, and fix minor typos. Add GermlineSet and GenotypeSet to the list of high-level schema objects.