### PR TITLE
Expression

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -4105,12 +4105,23 @@ CellExpression:
     discriminator: AIRR
     type: object
     required:
+        - expression_id
         - reperotire_id
         - data_processing_id
         - cell_id
         - property
         - value
     properties:
+        expression_id:
+            type: string
+            description: >
+                Identifier of this expression property measurement.
+            title: Expression property measurement identifier
+            nullable: false
+            x-airr:
+                miairr: defined
+                adc-query-support: true
+                name: Expression measurement identifier
         cell_id:
             type: string
             description: >

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -4117,9 +4117,9 @@ CellExpression:
             description: >
                 Identifier of this expression property measurement.
             title: Expression property measurement identifier
-            nullable: false
             x-airr:
                 miairr: defined
+                nullable: false
                 adc-query-support: true
                 name: Expression measurement identifier
         cell_id:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -4105,12 +4105,23 @@ CellExpression:
     discriminator: AIRR
     type: object
     required:
+        - expression_id
         - reperotire_id
         - data_processing_id
         - cell_id
         - property
         - value
     properties:
+        expression_id:
+            type: string
+            description: >
+                Identifier of this expression property measurement.
+            title: Expression property measurement identifier
+            nullable: false
+            x-airr:
+                miairr: defined
+                adc-query-support: true
+                name: Expression measurement identifier
         cell_id:
             type: string
             description: >

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -4117,9 +4117,9 @@ CellExpression:
             description: >
                 Identifier of this expression property measurement.
             title: Expression property measurement identifier
-            nullable: false
             x-airr:
                 miairr: defined
+                nullable: false
                 adc-query-support: true
                 name: Expression measurement identifier
         cell_id:

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -747,6 +747,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/error_response'
   
+    /expression/{expression_id}:
+    x-swagger-router-controller: expression
+    get:
+      description: >
+        Returns an expression property based upon its identifier.
+      tags:
+        - expression
+      parameters:
+        - name: expression_id
+          in: path
+          description: ID of expression property to return
+          required: true
+          schema:
+            type: string
+      operationId: get_expression
+      responses:
+        '200':
+          description: >
+            A successful call returns the expression property data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/expression_id_response'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_response'
+  
   /expression:
     post:
       description: >

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -747,7 +747,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error_response'
   
-    /expression/{expression_id}:
+  /expression/{expression_id}:
     x-swagger-router-controller: expression
     get:
       description: >

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -405,6 +405,15 @@ components:
         Cell:
           $ref: '#/components/schemas/cell_list'
 
+    # The response object /expression/{expression_id} endpoint
+    expression_id_response:
+      type: object
+      properties:
+        Info:
+          $ref: '#/components/schemas/info_object'
+        Cell:
+          $ref: '#/components/schemas/expression_list'
+
     # The response object for the /expression endpoint
     expression_response:
       type: object

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -366,8 +366,17 @@ definitions:
   expression_list:
     type: array
     items:
-      $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Cell'
+      $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/CellExpression'
 
+  # The response object /expression/{expression_id} endpoint
+  expression_id_response:
+    type: object
+    properties:
+      Info:
+        $ref: '#/definitions/info_object'
+      Cell:
+        $ref: '#/definitions/expression_list'
+  
   # The response object for the /expression endpoint
   expression_response:
     type: object
@@ -789,6 +798,41 @@ paths:
             A successful call returns an array of cell annotation data.
           schema:
             $ref: '#/definitions/cell_response'
+        '400':
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/error_response'
+        '500':
+          description: Server error
+          schema:
+            $ref: '#/definitions/error_response'
+
+  /expression/{expression_id}:
+    x-swagger-router-controller: expression
+    get:
+      description: >
+        Returns an expression property based upon its identifier.
+      tags:
+        - expression
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+        - application/octet-stream
+      produces:
+        - application/json
+      parameters:
+        - name: expression_id
+          in: path
+          description: ID of expression property to return
+          required: true
+          type: string
+      operationId: getExpression
+      responses:
+        '200':
+          description: >
+            A successful call returns the expression property data.
+          schema:
+            $ref: '#/definitions/expression_id_response'
         '400':
           description: Invalid request
           schema:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -4320,6 +4320,7 @@ CellExpression:
         propertyName: AIRR
     type: object
     required:
+        - expression_id
         - reperotire_id
         - data_processing_id
         - cell_id

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -4326,6 +4326,16 @@ CellExpression:
         - property
         - value
     properties:
+        expression_id:
+            type: string
+            description: >
+                Identifier of this expression property measurement.
+            title: Expression property measurement identifier
+            nullable: false
+            x-airr:
+                miairr: defined
+                adc-query-support: true
+                name: Expression measurement identifier
         cell_id:
             type: string
             description: >

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -4105,12 +4105,23 @@ CellExpression:
     discriminator: AIRR
     type: object
     required:
+        - expression_id
         - reperotire_id
         - data_processing_id
         - cell_id
         - property
         - value
     properties:
+        expression_id:
+            type: string
+            description: >
+                Identifier of this expression property measurement.
+            title: Expression property measurement identifier
+            x-airr:
+                miairr: defined
+                nullable: false
+                adc-query-support: true
+                name: Expression measurement identifier
         cell_id:
             type: string
             description: >


### PR DESCRIPTION
We overlooked providing an object id for the CellExpression object, realized this when I added the API docs...