### PR TITLE
Minor fixes to ADC API schema files

### DIFF
--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -423,7 +423,7 @@ components:
       properties:
         Info:
           $ref: '#/components/schemas/info_object'
-        Cell:
+        CellExpression:
           $ref: '#/components/schemas/expression_list'
 
     # The response object for the /expression endpoint

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -374,7 +374,7 @@ definitions:
     properties:
       Info:
         $ref: '#/definitions/info_object'
-      Cell:
+      CellExpression:
         $ref: '#/definitions/expression_list'
   
   # The response object for the /expression endpoint


### PR DESCRIPTION
Both ADC API schema files currently define for the `expression_id_response` object (response of the `/expression/{expression_id}` endpoint) a `Cell` property that IMO should be called `CellProperty`. This patch fixes this issue.