### PR TITLE
Add test for reading zipped rearrangements in R

### DIFF
--- a/lang/R/tests/testthat/test-Interface.R
+++ b/lang/R/tests/testthat/test-Interface.R
@@ -32,6 +32,24 @@ test_that("read_airr_tsv loads a data.frame", {
     expect_true(is.data.frame(tbl_1))
 })
 
+test_that("read_airr_tsv reads zipped tsv", {
+  # Create test data gzip
+  tmp_file <- tempfile(fileext = ".tsv.gz")
+
+  x <- readr::read_tsv(rearrangement_file)
+  readr::write_tsv(x, file = tmp_file)
+
+  tbl_1 <- read_airr_tsv(tmp_file, "1", schema = RearrangementSchema)
+  expect_true(is.data.frame(tbl_1))
+
+  # bzip2
+  tmp_file <- tempfile(fileext = ".tsv.bz2")
+  readr::write_tsv(x, file = tmp_file)
+
+  tbl_1 <- read_airr_tsv(tmp_file, "1", schema = RearrangementSchema)
+  expect_true(is.data.frame(tbl_1))
+})
+
 test_that("read_airr_tsv applies base", {
     tbl_0 <- read_airr_tsv(rearrangement_file, "0", schema = RearrangementSchema)
     tbl_1 <- read_airr_tsv(rearrangement_file, "1", schema = RearrangementSchema)


### PR DESCRIPTION
A single test to capture reading of gzipped rearrangements in R

The example for `read_airr_tsv()` always made  use of a gzipped file. The test just moves this check away from the full package check.

These changes mirrors the work in #618 for the python library.