### PR TITLE
Move ADC custom fields to ADC extensions mechanism

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1546,29 +1546,6 @@ Study:
                 subset: study
                 name: Keywords for study
                 format: controlled vocabulary
-        adc_publish_date:
-            type: string
-            format: date-time
-            description: >
-                Date the study was first published in the AIRR Data Commons.
-            title: ADC Publish Date
-            example: "2021-02-02"
-            x-airr:
-                nullable: true
-                adc-query-support: true
-                name: ADC Publish Date
-        adc_update_date:
-            type: string
-            format: date-time
-            description: >
-                Date the study data was updated in the AIRR Data Commons.
-            title: ADC Update Date
-            example: "2021-02-02"
-            x-airr:
-                nullable: true
-                adc-query-support: true
-                name: ADC Update Date
-
 
 # 1-to-n relationship between a study and its subjects
 # subject_id is unique within a study
@@ -4205,16 +4182,6 @@ Cell:
                 nullable: true
                 adc-query-support: true
                 name: Virtual pairing
-        adc_annotation_cell_id:
-            type: string
-            description: >
-              The Cell ID used by the annotation tool to annotate the Cell during data processing.
-            example: AAACCTGAGCACCGCT-1
-            x-airr:
-              nullable: true
-              adc-api-optional: false
-              adc-query_support: true
-              name: Tool Cell ID
 
 # The CellExpression object acts as a container to hold a single expression level measurement from
 # an experiment. Expression data is associated with a cell_id and the related repertoire_id and 

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1546,6 +1546,28 @@ Study:
                 subset: study
                 name: Keywords for study
                 format: controlled vocabulary
+        adc_publish_date:
+            type: string
+            format: date-time
+            description: >
+                Date the study was first published in the AIRR Data Commons.
+            title: ADC Publish Date
+            example: "2021-02-02"
+            x-airr:
+                nullable: true
+                adc-query-support: true
+                name: ADC Publish Date
+        adc_update_date:
+            type: string
+            format: date-time
+            description: >
+                Date the study data was updated in the AIRR Data Commons.
+            title: ADC Update Date
+            example: "2021-02-02"
+            x-airr:
+                nullable: true
+                adc-query-support: true
+                name: ADC Update Date
 
 # 1-to-n relationship between a study and its subjects
 # subject_id is unique within a study

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1546,29 +1546,6 @@ Study:
                 subset: study
                 name: Keywords for study
                 format: controlled vocabulary
-        adc_publish_date:
-            type: string
-            format: date-time
-            description: >
-                Date the study was first published in the AIRR Data Commons.
-            title: ADC Publish Date
-            example: "2021-02-02"
-            x-airr:
-                nullable: true
-                adc-query-support: true
-                name: ADC Publish Date
-        adc_update_date:
-            type: string
-            format: date-time
-            description: >
-                Date the study data was updated in the AIRR Data Commons.
-            title: ADC Update Date
-            example: "2021-02-02"
-            x-airr:
-                nullable: true
-                adc-query-support: true
-                name: ADC Update Date
-
 
 # 1-to-n relationship between a study and its subjects
 # subject_id is unique within a study
@@ -4205,16 +4182,6 @@ Cell:
                 nullable: true
                 adc-query-support: true
                 name: Virtual pairing
-        adc_annotation_cell_id:
-            type: string
-            description: >
-              The Cell ID used by the annotation tool to annotate the Cell during data processing.
-            example: AAACCTGAGCACCGCT-1
-            x-airr:
-              nullable: true
-              adc-api-optional: false
-              adc-query_support: true
-              name: Tool Cell ID
 
 # The CellExpression object acts as a container to hold a single expression level measurement from
 # an experiment. Expression data is associated with a cell_id and the related repertoire_id and 

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1546,6 +1546,28 @@ Study:
                 subset: study
                 name: Keywords for study
                 format: controlled vocabulary
+        adc_publish_date:
+            type: string
+            format: date-time
+            description: >
+                Date the study was first published in the AIRR Data Commons.
+            title: ADC Publish Date
+            example: "2021-02-02"
+            x-airr:
+                nullable: true
+                adc-query-support: true
+                name: ADC Publish Date
+        adc_update_date:
+            type: string
+            format: date-time
+            description: >
+                Date the study data was updated in the AIRR Data Commons.
+            title: ADC Update Date
+            example: "2021-02-02"
+            x-airr:
+                nullable: true
+                adc-query-support: true
+                name: ADC Update Date
 
 # 1-to-n relationship between a study and its subjects
 # subject_id is unique within a study

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -112,6 +112,36 @@ components:
       items:
         $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Repertoire'
 
+    # list of study extension fields
+    study_extension:
+      description: The extended Study object with additional query fields for the ADC.
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Study'
+        - type: object
+          properties:
+            adc_publish_date:
+              type: string
+              format: date-time
+              nullable: true
+              description: >
+                Date the study was first published in the AIRR Data Commons.
+              title: ADC Publish Date
+              example: "2021-02-02"
+              x-airr:
+                adc-query-support: true
+                name: ADC Publish Date
+            adc_update_date:
+              type: string
+              format: date-time
+              nullable: true
+              description: >
+                Date the study data was updated in the AIRR Data Commons.
+              title: ADC Update Date
+              example: "2021-02-02"
+              x-airr:
+                adc-query-support: true
+                name: ADC Update Date
+
     # list of facets
     facet_list:
       type: array
@@ -330,6 +360,18 @@ components:
       description: The extended Cell object with additional query fields for the ADC.
       allOf:
         - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Cell'
+        - type: object
+          properties:
+            adc_annotation_cell_id:
+              type: string
+              nullable: true
+              description: >
+                The Cell ID used by the annotation tool to annotate the Cell during data processing.
+              example: AAACCTGAGCACCGCT-1
+              x-airr:
+                adc-api-optional: false
+                adc-query_support: true
+                name: Tool Cell ID
 
     # list of cell annotations
     cell_list:

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -246,6 +246,16 @@ components:
                 adc-api-optional: false
                 adc-query_support: true
                 name: C gene
+            adc_annotation_cell_id:
+              type: string
+              nullable: true
+              description: >
+                The Cell ID used by the annotation tool to annotate the Cell during data processing.
+              example: AAACCTGAGCACCGCT-1
+              x-airr:
+                adc-api-optional: false
+                adc-query_support: true
+                name: Tool Cell ID
               
     # list of rearrangement annotations
     rearrangement_list:

--- a/specs/adc-api-openapi3.yaml
+++ b/specs/adc-api-openapi3.yaml
@@ -112,36 +112,6 @@ components:
       items:
         $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Repertoire'
 
-    # list of study extension fields
-    study_extension:
-      description: The extended Study object with additional query fields for the ADC.
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema-openapi3.yaml#/Study'
-        - type: object
-          properties:
-            adc_publish_date:
-              type: string
-              format: date-time
-              nullable: true
-              description: >
-                Date the study was first published in the AIRR Data Commons.
-              title: ADC Publish Date
-              example: "2021-02-02"
-              x-airr:
-                adc-query-support: true
-                name: ADC Publish Date
-            adc_update_date:
-              type: string
-              format: date-time
-              nullable: true
-              description: >
-                Date the study data was updated in the AIRR Data Commons.
-              title: ADC Update Date
-              example: "2021-02-02"
-              x-airr:
-                adc-query-support: true
-                name: ADC Update Date
-
     # list of facets
     facet_list:
       type: array

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -95,36 +95,6 @@ definitions:
       Facet:
         $ref: '#/definitions/facet_list'
 
-  # list of study extension fields
-  study_extension:
-    description: The extended Study object with additional query fields for the ADC.
-    allOf:
-      - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Study'
-      - type: object
-        properties:
-          adc_publish_date:
-            type: string
-            format: date-time
-            description: >
-              Date the study was first published in the AIRR Data Commons.
-            title: ADC Publish Date
-            example: "2021-02-02"
-            x-airr:
-              nullable: true
-              adc-query-support: true
-              name: ADC Publish Date
-          adc_update_date:
-            type: string
-            format: date-time
-            description: >
-              Date the study data was updated in the AIRR Data Commons.
-            title: ADC Update Date
-            example: "2021-02-02"
-            x-airr:
-              nullable: true
-              adc-query-support: true
-              name: ADC Update Date
-
   # list of rearrangement extension fields
   rearrangement_extension:
     description: The extended Rearrangement object with additional query fields for the ADC.

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -220,6 +220,16 @@ definitions:
               adc-api-optional: false
               adc-query_support: true
               name: C gene
+          adc_annotation_cell_id:
+            type: string
+            description: >
+              The Cell ID used by the annotation tool to annotate the Cell during data processing.
+            example: AAACCTGAGCACCGCT-1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: Tool Cell ID
 
   # list of rearrangement annotations
   rearrangement_list:

--- a/specs/adc-api.yaml
+++ b/specs/adc-api.yaml
@@ -94,7 +94,37 @@ definitions:
         $ref: '#/definitions/repertoire_list'
       Facet:
         $ref: '#/definitions/facet_list'
-        
+
+  # list of study extension fields
+  study_extension:
+    description: The extended Study object with additional query fields for the ADC.
+    allOf:
+      - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Study'
+      - type: object
+        properties:
+          adc_publish_date:
+            type: string
+            format: date-time
+            description: >
+              Date the study was first published in the AIRR Data Commons.
+            title: ADC Publish Date
+            example: "2021-02-02"
+            x-airr:
+              nullable: true
+              adc-query-support: true
+              name: ADC Publish Date
+          adc_update_date:
+            type: string
+            format: date-time
+            description: >
+              Date the study data was updated in the AIRR Data Commons.
+            title: ADC Update Date
+            example: "2021-02-02"
+            x-airr:
+              nullable: true
+              adc-query-support: true
+              name: ADC Update Date
+
   # list of rearrangement extension fields
   rearrangement_extension:
     description: The extended Rearrangement object with additional query fields for the ADC.
@@ -335,6 +365,18 @@ definitions:
     description: The extended Cell object with additional query fields for the ADC.
     allOf:
       - $ref: 'https://raw.githubusercontent.com/airr-community/airr-standards/master/specs/airr-schema.yaml#/Cell'
+      - type: object
+        properties:
+          adc_annotation_cell_id:
+            type: string
+            description: >
+              The Cell ID used by the annotation tool to annotate the Cell during data processing.
+            example: AAACCTGAGCACCGCT-1
+            x-airr:
+              nullable: true
+              adc-api-optional: false
+              adc-query_support: true
+              name: Tool Cell ID
 
   # list of cell annotations
   cell_list:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -1546,28 +1546,6 @@ Study:
                 subset: study
                 name: Keywords for study
                 format: controlled vocabulary
-        adc_publish_date:
-            type: string
-            format: date-time
-            nullable: true
-            description: >
-                Date the study was first published in the AIRR Data Commons.
-            title: ADC Publish Date
-            example: "2021-02-02"
-            x-airr:
-                adc-query-support: true
-                name: ADC Publish Date
-        adc_update_date:
-            type: string
-            format: date-time
-            nullable: true
-            description: >
-                Date the study data was updated in the AIRR Data Commons.
-            title: ADC Update Date
-            example: "2021-02-02"
-            x-airr:
-                adc-query-support: true
-                name: ADC Update Date
 
 # 1-to-n relationship between a study and its subjects
 # subject_id is unique within a study
@@ -4418,16 +4396,6 @@ Cell:
                 miairr: defined
                 adc-query-support: true
                 name: Virtual pairing
-        adc_annotation_cell_id:
-            type: string
-            nullable: true
-            description: >
-              The Cell ID used by the annotation tool to annotate the Cell during data processing.
-            example: AAACCTGAGCACCGCT-1
-            x-airr:
-              adc-api-optional: false
-              adc-query_support: true
-              name: Tool Cell ID
 
 # The CellExpression object acts as a container to hold a single expression level measurement from
 # an experiment. Expression data is associated with a cell_id and the related repertoire_id and 

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -1546,6 +1546,28 @@ Study:
                 subset: study
                 name: Keywords for study
                 format: controlled vocabulary
+        adc_publish_date:
+            type: string
+            format: date-time
+            nullable: true
+            description: >
+                Date the study was first published in the AIRR Data Commons.
+            title: ADC Publish Date
+            example: "2021-02-02"
+            x-airr:
+                adc-query-support: true
+                name: ADC Publish Date
+        adc_update_date:
+            type: string
+            format: date-time
+            nullable: true
+            description: >
+                Date the study data was updated in the AIRR Data Commons.
+            title: ADC Update Date
+            example: "2021-02-02"
+            x-airr:
+                adc-query-support: true
+                name: ADC Update Date
 
 # 1-to-n relationship between a study and its subjects
 # subject_id is unique within a study

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1546,29 +1546,6 @@ Study:
                 subset: study
                 name: Keywords for study
                 format: controlled vocabulary
-        adc_publish_date:
-            type: string
-            format: date-time
-            description: >
-                Date the study was first published in the AIRR Data Commons.
-            title: ADC Publish Date
-            example: "2021-02-02"
-            x-airr:
-                nullable: true
-                adc-query-support: true
-                name: ADC Publish Date
-        adc_update_date:
-            type: string
-            format: date-time
-            description: >
-                Date the study data was updated in the AIRR Data Commons.
-            title: ADC Update Date
-            example: "2021-02-02"
-            x-airr:
-                nullable: true
-                adc-query-support: true
-                name: ADC Update Date
-
 
 # 1-to-n relationship between a study and its subjects
 # subject_id is unique within a study
@@ -4205,16 +4182,6 @@ Cell:
                 nullable: true
                 adc-query-support: true
                 name: Virtual pairing
-        adc_annotation_cell_id:
-            type: string
-            description: >
-              The Cell ID used by the annotation tool to annotate the Cell during data processing.
-            example: AAACCTGAGCACCGCT-1
-            x-airr:
-              nullable: true
-              adc-api-optional: false
-              adc-query_support: true
-              name: Tool Cell ID
 
 # The CellExpression object acts as a container to hold a single expression level measurement from
 # an experiment. Expression data is associated with a cell_id and the related repertoire_id and 

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1546,6 +1546,28 @@ Study:
                 subset: study
                 name: Keywords for study
                 format: controlled vocabulary
+        adc_publish_date:
+            type: string
+            format: date-time
+            description: >
+                Date the study was first published in the AIRR Data Commons.
+            title: ADC Publish Date
+            example: "2021-02-02"
+            x-airr:
+                nullable: true
+                adc-query-support: true
+                name: ADC Publish Date
+        adc_update_date:
+            type: string
+            format: date-time
+            description: >
+                Date the study data was updated in the AIRR Data Commons.
+            title: ADC Update Date
+            example: "2021-02-02"
+            x-airr:
+                nullable: true
+                adc-query-support: true
+                name: ADC Update Date
 
 # 1-to-n relationship between a study and its subjects
 # subject_id is unique within a study


### PR DESCRIPTION
Following up on #602. Moved the ADC custom fields to the ADC extensions mechanism, per the decision in #589 and related issues.

Specifically:
* `adc_publish_date`, `adc_update_date` to`study_extension`
* `adc_annotation_cell_id` to `cell_extension`, `rearrangement_extension`