### PR TITLE
DataFile and RepertoireGroup modifications

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -345,44 +345,16 @@ DataFile:
                 nullable: false
         Repertoire:
             type: array
-            description: List of Repertoire metadata
+            description: List of repertoires
             items:
                 $ref: '#/Repertoire'
             x-airr:
                 nullable: false
-        RepertoireGroup:
+        RepertoireSet:
             type: array
-            description: List of Repertoire groups
+            description: List of repertoire sets
             items:
-                $ref: '#/RepertoireGroup'
-            x-airr:
-                nullable: false
-        AlleleDescription:
-            type: array
-            description: List of allele descriptions
-            items:
-              $ref: '#/AlleleDescription'
-            x-airr:
-                nullable: false
-        GermlineSet:
-            type: array
-            description: List of germline sets
-            items:
-              $ref: '#/GermlineSet'
-            x-airr:
-                nullable: false
-        DataProcessing:
-            type: array
-            description: List of data processing workflows
-            items:
-                $ref: '#/DataProcessing'
-            x-airr:
-                nullable: false
-        Cell:
-            type: array
-            description: List of cells
-            items:
-                $ref: '#/Cell'
+                $ref: '#/RepertoireSet'
             x-airr:
                 nullable: false
         Rearrangement:
@@ -392,6 +364,13 @@ DataFile:
                 $ref: '#/Rearrangement'
             x-airr:
                 nullable: false
+        Cell:
+            type: array
+            description: List of cells
+            items:
+                $ref: '#/Cell'
+            x-airr:
+                nullable: false
         Clone:
             type: array
             description: List of clones
@@ -399,11 +378,18 @@ DataFile:
                 $ref: '#/Clone'
             x-airr:
                 nullable: false
-        Tree:
+        GermlineSet:
             type: array
-            description: List of trees
+            description: List of germline sets
             items:
-                $ref: '#/Tree'
+                $ref: '#/GermlineSet'
+            x-airr:
+                nullable: false
+        GenotypeSet:
+            type: array
+            description: List of genotype sets
+            items:
+                $ref: '#/GenotypeSet'
             x-airr:
                 nullable: false
 
@@ -2989,20 +2975,20 @@ Repertoire:
                 adc-query-support: true
 
 # A collection of repertoires for analysis purposes, includes optional time course
-RepertoireGroup:
+RepertoireSet:
     discriminator: AIRR
     type: object
     required:
-        - repertoire_group_id
+        - repertoire_set_id
         - repertoires
     properties:
-        repertoire_group_id:
+        repertoire_set_id:
             type: string
             description: Identifier for this repertoire group
-        repertoire_group_name:
+        repertoire_set_name:
             type: string
             description: Short display name for this repertoire group
-        repertoire_group_description:
+        repertoire_set_description:
             type: string
             description: Repertoire group description
         repertoires:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -345,44 +345,16 @@ DataFile:
                 nullable: false
         Repertoire:
             type: array
-            description: List of Repertoire metadata
+            description: List of repertoires
             items:
                 $ref: '#/Repertoire'
             x-airr:
                 nullable: false
-        RepertoireGroup:
+        RepertoireSet:
             type: array
-            description: List of Repertoire groups
+            description: List of repertoire sets
             items:
-                $ref: '#/RepertoireGroup'
-            x-airr:
-                nullable: false
-        AlleleDescription:
-            type: array
-            description: List of allele descriptions
-            items:
-              $ref: '#/AlleleDescription'
-            x-airr:
-                nullable: false
-        GermlineSet:
-            type: array
-            description: List of germline sets
-            items:
-              $ref: '#/GermlineSet'
-            x-airr:
-                nullable: false
-        DataProcessing:
-            type: array
-            description: List of data processing workflows
-            items:
-                $ref: '#/DataProcessing'
-            x-airr:
-                nullable: false
-        Cell:
-            type: array
-            description: List of cells
-            items:
-                $ref: '#/Cell'
+                $ref: '#/RepertoireSet'
             x-airr:
                 nullable: false
         Rearrangement:
@@ -392,6 +364,13 @@ DataFile:
                 $ref: '#/Rearrangement'
             x-airr:
                 nullable: false
+        Cell:
+            type: array
+            description: List of cells
+            items:
+                $ref: '#/Cell'
+            x-airr:
+                nullable: false
         Clone:
             type: array
             description: List of clones
@@ -399,11 +378,18 @@ DataFile:
                 $ref: '#/Clone'
             x-airr:
                 nullable: false
-        Tree:
+        GermlineSet:
             type: array
-            description: List of trees
+            description: List of germline sets
             items:
-                $ref: '#/Tree'
+                $ref: '#/GermlineSet'
+            x-airr:
+                nullable: false
+        GenotypeSet:
+            type: array
+            description: List of genotype sets
+            items:
+                $ref: '#/GenotypeSet'
             x-airr:
                 nullable: false
 
@@ -2989,20 +2975,20 @@ Repertoire:
                 adc-query-support: true
 
 # A collection of repertoires for analysis purposes, includes optional time course
-RepertoireGroup:
+RepertoireSet:
     discriminator: AIRR
     type: object
     required:
-        - repertoire_group_id
+        - repertoire_set_id
         - repertoires
     properties:
-        repertoire_group_id:
+        repertoire_set_id:
             type: string
             description: Identifier for this repertoire group
-        repertoire_group_name:
+        repertoire_set_name:
             type: string
             description: Short display name for this repertoire group
-        repertoire_group_description:
+        repertoire_set_description:
             type: string
             description: Repertoire group description
         repertoires:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -346,57 +346,45 @@ DataFile:
         Repertoire:
             type: array
             nullable: false
-            description: List of Repertoire metadata
+            description: List of repertoires
             items:
               $ref: '#/Repertoire'
-        RepertoireGroup:
+        RepertoireSet:
             type: array
             nullable: false
-            description: List of Repertoire groups
+            description: List of repertoire sets
             items:
-              $ref: '#/RepertoireGroup'
-        AlleleDescription:
+              $ref: '#/RepertoireSet'
+        Rearrangement:
             type: array
             nullable: false
-            description: List of allele descriptions
+            description: List of rearrangement records
             items:
-              $ref: '#/AlleleDescription'
-        GermlineSet:
-            type: array
-            nullable: false
-            description: List of germline sets
-            items:
-              $ref: '#/GermlineSet'
-        DataProcessing:
-            type: array
-            nullable: false
-            description: List of data processing workflows
-            items:
-              $ref: '#/DataProcessing'
+                $ref: '#/Rearrangement'
         Cell:
             type: array
             nullable: false
             description: List of cells
             items:
               $ref: '#/Cell'
-        Rearrangement:
-            type: array
-            nullable: false
-            description: List of rearrangement records
-            items:
-              $ref: '#/Rearrangement'
         Clone:
             type: array
             nullable: false
             description: List of clones
             items:
               $ref: '#/Clone'
-        Tree:
+        GermlineSet:
             type: array
             nullable: false
-            description: List of trees
+            description: List of germline sets
             items:
-              $ref: '#/Tree'
+                $ref: '#/GermlineSet'
+        GenotypeSet:
+            type: array
+            nullable: false
+            description: List of genotype sets
+            items:
+                $ref: '#/GenotypeSet'
 
 # AIRR Info object, should be similar to openapi
 # should we point to an openapi schema?
@@ -3004,23 +2992,23 @@ Repertoire:
                 adc-query-support: true
 
 # A collection of repertoires for analysis purposes, includes optional time course
-RepertoireGroup:
+RepertoireSet:
     discriminator:
         propertyName: AIRR
     type: object
     required:
-        - repertoire_group_id
+        - repertoire_set_id
         - repertoires
     properties:
-        repertoire_group_id:
+        repertoire_set_id:
             type: string
             nullable: true
             description: Identifier for this repertoire group
-        repertoire_group_name:
+        repertoire_set_name:
             type: string
             nullable: true
             description: Short display name for this repertoire group
-        repertoire_group_description:
+        repertoire_set_description:
             type: string
             nullable: true
             description: Repertoire group description

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -345,44 +345,16 @@ DataFile:
                 nullable: false
         Repertoire:
             type: array
-            description: List of Repertoire metadata
+            description: List of repertoires
             items:
                 $ref: '#/Repertoire'
             x-airr:
                 nullable: false
-        RepertoireGroup:
+        RepertoireSet:
             type: array
-            description: List of Repertoire groups
+            description: List of repertoire sets
             items:
-                $ref: '#/RepertoireGroup'
-            x-airr:
-                nullable: false
-        AlleleDescription:
-            type: array
-            description: List of allele descriptions
-            items:
-              $ref: '#/AlleleDescription'
-            x-airr:
-                nullable: false
-        GermlineSet:
-            type: array
-            description: List of germline sets
-            items:
-              $ref: '#/GermlineSet'
-            x-airr:
-                nullable: false
-        DataProcessing:
-            type: array
-            description: List of data processing workflows
-            items:
-                $ref: '#/DataProcessing'
-            x-airr:
-                nullable: false
-        Cell:
-            type: array
-            description: List of cells
-            items:
-                $ref: '#/Cell'
+                $ref: '#/RepertoireSet'
             x-airr:
                 nullable: false
         Rearrangement:
@@ -392,6 +364,13 @@ DataFile:
                 $ref: '#/Rearrangement'
             x-airr:
                 nullable: false
+        Cell:
+            type: array
+            description: List of cells
+            items:
+                $ref: '#/Cell'
+            x-airr:
+                nullable: false
         Clone:
             type: array
             description: List of clones
@@ -399,11 +378,18 @@ DataFile:
                 $ref: '#/Clone'
             x-airr:
                 nullable: false
-        Tree:
+        GermlineSet:
             type: array
-            description: List of trees
+            description: List of germline sets
             items:
-                $ref: '#/Tree'
+                $ref: '#/GermlineSet'
+            x-airr:
+                nullable: false
+        GenotypeSet:
+            type: array
+            description: List of genotype sets
+            items:
+                $ref: '#/GenotypeSet'
             x-airr:
                 nullable: false
 
@@ -2989,20 +2975,20 @@ Repertoire:
                 adc-query-support: true
 
 # A collection of repertoires for analysis purposes, includes optional time course
-RepertoireGroup:
+RepertoireSet:
     discriminator: AIRR
     type: object
     required:
-        - repertoire_group_id
+        - repertoire_set_id
         - repertoires
     properties:
-        repertoire_group_id:
+        repertoire_set_id:
             type: string
             description: Identifier for this repertoire group
-        repertoire_group_name:
+        repertoire_set_name:
             type: string
             description: Short display name for this repertoire group
-        repertoire_group_description:
+        repertoire_set_description:
             type: string
             description: Repertoire group description
         repertoires:


### PR DESCRIPTION
Per #581, `DataFile` changes:
* Remove `AlleleDescription`, `DataProcessing`, and `Tree`
* Add `GenotypeSet`

Per the August 8, 2022 call:
* Rename `RepertoireGroup` to `RepertoireSet` for consistency with other schema.