### PR TITLE
Change `RepertoireSet` to `RepertoireGroup`

### DIFF
--- a/docs/standards/news.rst
+++ b/docs/standards/news.rst
@@ -13,8 +13,8 @@ New General Purpose Schema:
 1. Introduced the experimental ``DataFile`` object, which defines a JSON file
    holding Repertoire metadata, data processing analysis objects, or any object
    in the AIRR Data Model.
-2. Introduced the experimental ``RepertoireSet`` Schema for describing sets
-   of repertoires to be analyzed together.
+2. Introduced the experimental ``RepertoireGroup`` Schema for describing
+   collections of repertoires to be analyzed together.
 3. Introduced the experimental ``InfoObject`` Schema, which provides information
    about data and ADC API responses.
 4. Introduced the experimental ``TimePoint`` Schema for defining the time point

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -350,11 +350,11 @@ DataFile:
                 $ref: '#/Repertoire'
             x-airr:
                 nullable: false
-        RepertoireSet:
+        RepertoireGroup:
             type: array
-            description: List of repertoire sets
+            description: List of repertoire collections
             items:
-                $ref: '#/RepertoireSet'
+                $ref: '#/RepertoireGroup'
             x-airr:
                 nullable: false
         Rearrangement:
@@ -2975,7 +2975,7 @@ Repertoire:
                 adc-query-support: true
 
 # A collection of repertoires for analysis purposes, includes optional time course
-RepertoireSet:
+RepertoireGroup:
     discriminator: AIRR
     type: object
     required:

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -393,7 +393,6 @@ DataFile:
             x-airr:
                 nullable: false
 
-
 # AIRR Info object, should be similar to openapi
 # should we point to an openapi schema?
 InfoObject:
@@ -2979,22 +2978,22 @@ RepertoireGroup:
     discriminator: AIRR
     type: object
     required:
-        - repertoire_set_id
+        - repertoire_group_id
         - repertoires
     properties:
-        repertoire_set_id:
+        repertoire_group_id:
             type: string
-            description: Identifier for this repertoire group
-        repertoire_set_name:
+            description: Identifier for this repertoire collection
+        repertoire_group_name:
             type: string
-            description: Short display name for this repertoire group
-        repertoire_set_description:
+            description: Short display name for this repertoire collection
+        repertoire_group_description:
             type: string
-            description: Repertoire group description
+            description: Repertoire collection description
         repertoires:
             type: array
             description: >
-                List of repertoires in this group with an associated description and time point designation
+                List of repertoires in this collection with an associated description and time point designation
             items:
                 type: object
                 properties:

--- a/lang/python/airr/schema.py
+++ b/lang/python/airr/schema.py
@@ -513,6 +513,7 @@ AIRRSchema = {
     'Alignment': Schema('Alignment'),
     'Rearrangement': Schema('Rearrangement'),
     'Repertoire': Schema('Repertoire'),
+    'RepertoireGroup': Schema('RepertoireGroup'),
     'Ontology': Schema('Ontology'),
     'Study': Schema('Study'),
     'Subject': Schema('Subject'),

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -350,11 +350,11 @@ DataFile:
                 $ref: '#/Repertoire'
             x-airr:
                 nullable: false
-        RepertoireSet:
+        RepertoireGroup:
             type: array
-            description: List of repertoire sets
+            description: List of repertoire collections
             items:
-                $ref: '#/RepertoireSet'
+                $ref: '#/RepertoireGroup'
             x-airr:
                 nullable: false
         Rearrangement:
@@ -2974,26 +2974,26 @@ Repertoire:
                 adc-query-support: true
 
 # A collection of repertoires for analysis purposes, includes optional time course
-RepertoireSet:
+RepertoireGroup:
     discriminator: AIRR
     type: object
     required:
-        - repertoire_set_id
+        - repertoire_group_id
         - repertoires
     properties:
-        repertoire_set_id:
+        repertoire_group_id:
             type: string
-            description: Identifier for this repertoire group
-        repertoire_set_name:
+            description: Identifier for this repertoire collection
+        repertoire_group_name:
             type: string
-            description: Short display name for this repertoire group
-        repertoire_set_description:
+            description: Short display name for this repertoire collection
+        repertoire_group_description:
             type: string
-            description: Repertoire group description
+            description: Repertoire collection description
         repertoires:
             type: array
             description: >
-                List of repertoires in this group with an associated description and time point designation
+                List of repertoires in this collection with an associated description and time point designation
             items:
                 type: object
                 properties:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -3016,7 +3016,7 @@ RepertoireGroup:
             type: array
             nullable: true
             description: >
-                List of repertoires in this group with an associated description and time point designation
+                List of repertoires in this collection with an associated description and time point designation
             items:
                 type: object
                 properties:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -349,12 +349,12 @@ DataFile:
             description: List of repertoires
             items:
               $ref: '#/Repertoire'
-        RepertoireSet:
+        RepertoireGroup:
             type: array
             nullable: false
-            description: List of repertoire sets
+            description: List of repertoire collections
             items:
-              $ref: '#/RepertoireSet'
+              $ref: '#/RepertoireGroup'
         Rearrangement:
             type: array
             nullable: false
@@ -2992,26 +2992,26 @@ Repertoire:
                 adc-query-support: true
 
 # A collection of repertoires for analysis purposes, includes optional time course
-RepertoireSet:
+RepertoireGroup:
     discriminator:
         propertyName: AIRR
     type: object
     required:
-        - repertoire_set_id
+        - repertoire_group_id
         - repertoires
     properties:
-        repertoire_set_id:
+        repertoire_group_id:
             type: string
             nullable: true
-            description: Identifier for this repertoire group
-        repertoire_set_name:
+            description: Identifier for this repertoire collection
+        repertoire_group_name:
             type: string
             nullable: true
-            description: Short display name for this repertoire group
-        repertoire_set_description:
+            description: Short display name for this repertoire collection
+        repertoire_group_description:
             type: string
             nullable: true
-            description: Repertoire group description
+            description: Repertoire collection description
         repertoires:
             type: array
             nullable: true

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -350,11 +350,11 @@ DataFile:
                 $ref: '#/Repertoire'
             x-airr:
                 nullable: false
-        RepertoireSet:
+        RepertoireGroup:
             type: array
-            description: List of repertoire sets
+            description: List of repertoire collections
             items:
-                $ref: '#/RepertoireSet'
+                $ref: '#/RepertoireGroup'
             x-airr:
                 nullable: false
         Rearrangement:
@@ -2974,26 +2974,26 @@ Repertoire:
                 adc-query-support: true
 
 # A collection of repertoires for analysis purposes, includes optional time course
-RepertoireSet:
+RepertoireGroup:
     discriminator: AIRR
     type: object
     required:
-        - repertoire_set_id
+        - repertoire_group_id
         - repertoires
     properties:
-        repertoire_set_id:
+        repertoire_group_id:
             type: string
-            description: Identifier for this repertoire group
-        repertoire_set_name:
+            description: Identifier for this repertoire collection
+        repertoire_group_name:
             type: string
-            description: Short display name for this repertoire group
-        repertoire_set_description:
+            description: Short display name for this repertoire collection
+        repertoire_group_description:
             type: string
-            description: Repertoire group description
+            description: Repertoire collection description
         repertoires:
             type: array
             description: >
-                List of repertoires in this group with an associated description and time point designation
+                List of repertoires in this collection with an associated description and time point designation
             items:
                 type: object
                 properties:


### PR DESCRIPTION
Closes #631. 

High probability this will change (or similar) in v2.0, but we're going to delay as there will be a number of backwards incompatible changes to `RepertoireGroup` in v2.0