### PR TITLE
Allow missing values in logical fields when validating tabular data

### DIFF
--- a/lang/R/R/Interface.R
+++ b/lang/R/R/Interface.R
@@ -531,7 +531,7 @@ validate_tabular <- function(data, schema) {
     logical_fields <- intersect(colnames(data), logical_fields)
     if (length(logical_fields) > 0 ) {
         for (log_field in logical_fields) {
-            not_logical <- data[[log_field]] %in% c(TRUE, FALSE) == FALSE
+            not_logical <- data[[log_field]] %in% c(TRUE, FALSE, NA) == FALSE
             if (any(not_logical)) {
                 warning(paste("Warning:",log_field,"is not logical for row(s):",
                               paste(which(not_logical), collapse = ", ")))            


### PR DESCRIPTION
This is regarding the R package.

Currently, when I use airr::read_rearrangement() I will get warnings like "Warning: vj_in_frame is not logical for row(s): ..." when the only values in that column are TRUE, FALSE, and NA. This stems from the fact that checks on the logical fields currently only allow TRUE and FALSE, not NA. I think that NA should be a valid value in a logical field.