### PR TITLE
RepertoireGroup development for v2.0

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -371,7 +371,7 @@ DataFile:
                 nullable: false
         RepertoireGroup:
             type: array
-            description: List of repertoire collections
+            description: List of repertoire groups
             items:
                 $ref: '#/RepertoireGroup'
             x-airr:
@@ -3191,7 +3191,8 @@ Repertoire:
                 nullable: false
                 adc-query-support: true
 
-# A collection of repertoires for analysis purposes, includes optional time course
+# An ordered group of repertoires for analysis purposes, includes optional time course
+# Can be treated as a set if all repertoire_group_id are unique
 RepertoireGroup:
     type: object
     required:
@@ -3200,19 +3201,19 @@ RepertoireGroup:
     properties:
         repertoire_group_id:
             type: string
-            description: Identifier for this repertoire collection
+            description: Identifier for this repertoire group
             x-airr:
                 identifier: true
         repertoire_group_name:
             type: string
-            description: Short display name for this repertoire collection
+            description: Short display name for this repertoire group
         repertoire_group_description:
             type: string
-            description: Repertoire collection description
+            description: Repertoire group description
         repertoires:
             type: array
             description: >
-                List of repertoires in this collection with an associated description and time point designation
+                List of repertoires in this group with an associated description and time point designation
             items:
                 type: object
                 properties:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -371,7 +371,7 @@ DataFile:
                 nullable: false
         RepertoireGroup:
             type: array
-            description: List of repertoire collections
+            description: List of repertoire groups
             items:
                 $ref: '#/RepertoireGroup'
             x-airr:
@@ -3191,7 +3191,8 @@ Repertoire:
                 nullable: false
                 adc-query-support: true
 
-# A collection of repertoires for analysis purposes, includes optional time course
+# An ordered group of repertoires for analysis purposes, includes optional time course
+# Can be treated as a set if all repertoire_group_id are unique
 RepertoireGroup:
     type: object
     required:
@@ -3200,19 +3201,19 @@ RepertoireGroup:
     properties:
         repertoire_group_id:
             type: string
-            description: Identifier for this repertoire collection
+            description: Identifier for this repertoire group
             x-airr:
                 identifier: true
         repertoire_group_name:
             type: string
-            description: Short display name for this repertoire collection
+            description: Short display name for this repertoire group
         repertoire_group_description:
             type: string
-            description: Repertoire collection description
+            description: Repertoire group description
         repertoires:
             type: array
             description: >
-                List of repertoires in this collection with an associated description and time point designation
+                List of repertoires in this group with an associated description and time point designation
             items:
                 type: object
                 properties:

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -368,7 +368,7 @@ DataFile:
         RepertoireGroup:
             type: array
             nullable: false
-            description: List of repertoire collections
+            description: List of repertoire groups
             items:
                 $ref: '#/RepertoireGroup'
         Rearrangement:
@@ -3293,7 +3293,8 @@ Repertoire:
             x-airr:
                 adc-query-support: true
 
-# A collection of repertoires for analysis purposes, includes optional time course
+# An ordered group of repertoires for analysis purposes, includes optional time course
+# Can be treated as a set if all repertoire_group_id are unique
 RepertoireGroup:
     type: object
     required:
@@ -3303,22 +3304,22 @@ RepertoireGroup:
         repertoire_group_id:
             type: string
             nullable: true
-            description: Identifier for this repertoire collection
+            description: Identifier for this repertoire group
             x-airr:
                 identifier: true
         repertoire_group_name:
             type: string
             nullable: true
-            description: Short display name for this repertoire collection
+            description: Short display name for this repertoire group
         repertoire_group_description:
             type: string
             nullable: true
-            description: Repertoire collection description
+            description: Repertoire group description
         repertoires:
             type: array
             nullable: true
             description: >
-                List of repertoires in this collection with an associated description and time point designation
+                List of repertoires in this group with an associated description and time point designation
             items:
                 type: object
                 properties:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -372,7 +372,6 @@ DataFile:
         RepertoireGroup:
             type: array
             description: List of repertoire groups
-            
             items:
                 $ref: '#/RepertoireGroup'
             x-airr:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -371,7 +371,8 @@ DataFile:
                 nullable: false
         RepertoireGroup:
             type: array
-            description: List of repertoire collections
+            description: List of repertoire groups
+            
             items:
                 $ref: '#/RepertoireGroup'
             x-airr:
@@ -3191,7 +3192,8 @@ Repertoire:
                 nullable: false
                 adc-query-support: true
 
-# A group of repertoires for analysis purposes, includes optional time course
+# An ordered group of repertoires for analysis purposes, includes optional time course
+# Can be treated as a set if all repertoire_group_id are unique
 RepertoireGroup:
     type: object
     required:
@@ -3200,19 +3202,19 @@ RepertoireGroup:
     properties:
         repertoire_group_id:
             type: string
-            description: Identifier for this repertoire collection
+            description: Identifier for this repertoire group
             x-airr:
                 identifier: true
         repertoire_group_name:
             type: string
-            description: Short display name for this repertoire collection
+            description: Short display name for this repertoire group
         repertoire_group_description:
             type: string
-            description: Repertoire collection description
+            description: Repertoire group description
         repertoires:
             type: array
             description: >
-                List of repertoires in this collection with an associated description and time point designation
+                List of repertoires in this group with an associated description and time point designation
             items:
                 type: object
                 properties:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -3191,7 +3191,7 @@ Repertoire:
                 nullable: false
                 adc-query-support: true
 
-# A collection of repertoires for analysis purposes, includes optional time course
+# A group of repertoires for analysis purposes, includes optional time course
 RepertoireGroup:
     type: object
     required:


### PR DESCRIPTION
In the descriptions of each field, it uses the wording "repertoire collection" not "repertoire group". Should this object be called `RepertoireCollection`

closes #578 