### PR TITLE
Restructuring of Cell

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -2516,7 +2516,8 @@ CellProcessing:
                         label: lymphocyte
         cell_phenotype:
             type: string
-            description: List of cellular markers and their expression levels used to isolate the cell population
+            description: >
+                List of cellular markers and their expression levels used to isolate the cell population.
             title: Cell subset phenotype
             example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:
@@ -4587,7 +4588,8 @@ Cell:
                         label: lymphocyte
         cell_phenotype:
             type: string
-            description: List of cellular markers and their expression levels used to isolate the cell population.
+            description: >
+                List of cellular markers and their expression levels used to isolate the cell population.
             title: Cell subset phenotype
             example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -2526,6 +2526,20 @@ CellProcessing:
                 set: 3
                 subset: process (cell)
                 name: Cell subset phenotype
+        cell_label:
+            type: string
+            description: >
+                Free text cell type annotation. Primarily used for annotating cell types that are not 
+                provided in the Cell Ontology.
+            title: Cell annotation
+            example: age-associated B cell
+            x-airr:
+                miairr: defined
+                nullable: true
+                adc-query-support: true
+                set: 3
+                subset: process (cell)
+                name: Cell annotation
         cell_species:
             $ref: '#/Ontology'
             description: >
@@ -4506,7 +4520,6 @@ Cell:
     type: object
     required:
         - cell_id
-        - rearrangements
         - repertoire_id
         - virtual_pairing
     properties:
@@ -4523,32 +4536,6 @@ Cell:
                 nullable: false
                 adc-query-support: true
                 name: Cell index
-        rearrangements:
-            type: array
-            description: >
-                Array of sequence identifiers defined for the Rearrangement objects associated with this cell
-            title: Cell-associated rearrangements
-            items:
-                type: string
-            example: [id1, id2]
-            x-airr:
-                miairr: defined
-                nullable: true
-                adc-query-support: true
-                name: Cell-associated rearrangements
-        receptors:
-            type: array
-            description: >
-                Array of receptor identifiers defined for the Receptor objects associated with this cell
-            title: Cell-associated receptors
-            items:
-                type: string
-            example: [id1, id2]
-            x-airr:
-                miairr: defined
-                nullable: true
-                adc-query-support: true
-                name: Cell-associated receptors
         repertoire_id:
             type: string
             description: Identifier to the associated repertoire in study metadata.
@@ -4567,34 +4554,59 @@ Cell:
                 nullable: true
                 adc-query-support: true
                 name: Data processing for cell
-        expression_study_method:
-            type: string
-            enum:
-                - flow_cytometry
-                - single-cell_transcriptome
-                - null
+        receptors:
+            type: array
             description: >
-                Keyword describing the methodology used to assess expression. This values for this field MUST 
-                come from a controlled vocabulary.
+                Array of receptor identifiers defined for the Receptor objects associated with this cell
+            title: Cell-associated receptors
+            items:
+                type: string
+            example: [id1, id2]
             x-airr:
                 miairr: defined
                 nullable: true
                 adc-query-support: true
-        expression_raw_doi:
+                name: Cell-associated receptors
+        cell_subset:
+            $ref: '#/Ontology'
+            description: Commonly-used designation of isolated cell population.
+            title: Cell subset
+            example:
+                id: CL:0000972
+                label: class switched memory B cell
+            x-airr:
+                miairr: important
+                nullable: true
+                adc-query-support: true
+                name: Cell subset
+                format: ontology
+                ontology:
+                    draft: false
+                    top_node:
+                        id: CL:0000542
+                        label: lymphocyte
+        cell_phenotype:
             type: string
-            description: >
-                DOI of raw data set containing the current event
+            description: List of cellular markers and their expression levels used to isolate the cell population.
+            title: Cell subset phenotype
+            example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:
                 miairr: defined
                 nullable: true
                 adc-query-support: true
-        expression_index:
+                name: Cell subset phenotype
+        cell_label:
             type: string
             description: >
-                Index addressing the current event within the raw data set.
+                Free text cell type annotation. Primarily used for annotating cell types that are not 
+                provided in the Cell Ontology.
+            title: Cell annotation
+            example: age-associated B cell
             x-airr:
                 miairr: defined
                 nullable: true
+                adc-query-support: true
+                name: Cell annotation
         virtual_pairing:
             type: boolean
             description: >
@@ -4606,10 +4618,10 @@ Cell:
                 adc-query-support: true
                 name: Virtual pairing
 
-# The CellExpression object acts as a container to hold a single expression level measurement from
+# The Expression object acts as a container to hold a single expression level measurement from
 # an experiment. Expression data is associated with a cell_id and the related repertoire_id and
-# data_processing_id 
-CellExpression:
+# data_processing_id
+Expression:
     type: object
     required:
         - expression_id
@@ -4623,7 +4635,7 @@ CellExpression:
         expression_id:
             type: string
             description: >
-                Identifier for the CellExpression object. This identifier must be unique within 
+                Identifier for the Expression object. This identifier must be unique within 
                 a given study, but it is recommended that it be a universally unique record locator
                 to enable database applications.
             title: Expression property measurement identifier
@@ -4807,12 +4819,12 @@ Receptor:
                 nullable: true
                 adc-query-support: true
 
-# The CellReactivity object holds information about the reactivity exhibited by a given Cell
+# The Reactivity object holds information about the reactivity exhibited by a given Cell
 #
-CellReactivity:
+Reactivity:
     type: object
     required:
-        - cell_reactivity_id
+        - reactivity_id
         - cell_id
         - ligand_type
         - antigen_type
@@ -4822,13 +4834,13 @@ CellReactivity:
         - reactivity_value
         - reactivity_unit
     properties:
-        cell_reactivity_id:
+        reactivity_id:
             type: string
             description: >
-                Identifier for the CellReactivity object. This identifier must be unique within 
+                Identifier for the Reactivity object. This identifier must be unique within 
                 a given study, but it is recommended that it be a universally unique record locator
                 to enable database applications.
-            title: CellReactivity ID
+            title: Reactivity ID
             x-airr:
                 identifier: true
                 nullable: false

--- a/lang/R/tests/data-tests/good_combined_airr.json
+++ b/lang/R/tests/data-tests/good_combined_airr.json
@@ -589,7 +589,7 @@
                         "label": "naive thymus-derived CD4-positive, alpha-beta T cell"
                     },
                     "cell_phenotype": "expression of CD8 and absence of CD4 and CD45RO",
-                    "cell_label": "naive CD4+ aB T cell",
+                    "cell_label": "naive CD4 aB T cell",
                     "cell_species": {
                         "id": "NCBITAXON:9606",
                         "label": "Homo sapiens"

--- a/lang/R/tests/data-tests/good_combined_airr.json
+++ b/lang/R/tests/data-tests/good_combined_airr.json
@@ -189,6 +189,7 @@
                         "label": "naive B cell"
                     },
                     "cell_phenotype": "expression of CD20 and the absence of CD27",
+                    "cell_label": "naive B cell",
                     "cell_species": {
                         "id": "NCBITAXON:9606",
                         "label": "Homo sapiens"
@@ -388,6 +389,7 @@
                         "label": "memory B cell"
                     },
                     "cell_phenotype": "expression of CD20 and CD27",
+                    "cell_label": "memory B cell",
                     "cell_species": {
                         "id": "NCBITAXON:9606",
                         "label": "Homo sapiens"
@@ -587,6 +589,7 @@
                         "label": "naive thymus-derived CD4-positive, alpha-beta T cell"
                     },
                     "cell_phenotype": "expression of CD8 and absence of CD4 and CD45RO",
+                    "cell_label": "naive CD4+ aB T cell",
                     "cell_species": {
                         "id": "NCBITAXON:9606",
                         "label": "Homo sapiens"

--- a/lang/R/tests/data-tests/good_combined_airr.yaml
+++ b/lang/R/tests/data-tests/good_combined_airr.yaml
@@ -142,10 +142,10 @@ Repertoire:
           id: CL:0000788
           label: naive B cell
         cell_phenotype: expression of CD20 and the absence of CD27
+        cell_label: naive B cell
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens
-        cell_label: naive B cell
         single_cell: false
         cell_isolation: FACS
         template_class: RNA
@@ -474,7 +474,7 @@ Repertoire:
           id: CL:0000895
           label: naive thymus-derived CD4-positive, alpha-beta T cell
         cell_phenotype: expression of CD8 and absence of CD4 and CD45RO
-        cell_label: naive CD4+ aB T cell
+        cell_label: naive CD4 aB T cell
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens

--- a/lang/R/tests/data-tests/good_combined_airr.yaml
+++ b/lang/R/tests/data-tests/good_combined_airr.yaml
@@ -145,6 +145,7 @@ Repertoire:
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens
+        cell_label: naive B cell
         single_cell: false
         cell_isolation: FACS
         template_class: RNA
@@ -307,6 +308,7 @@ Repertoire:
           id: CL:0000787
           label: memory B cell
         cell_phenotype: expression of CD20 and CD27
+        cell_label: memory B cell
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens
@@ -472,6 +474,7 @@ Repertoire:
           id: CL:0000895
           label: naive thymus-derived CD4-positive, alpha-beta T cell
         cell_phenotype: expression of CD8 and absence of CD4 and CD45RO
+        cell_label: naive CD4+ aB T cell
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens

--- a/lang/R/tests/data-tests/good_repertoire.yaml
+++ b/lang/R/tests/data-tests/good_repertoire.yaml
@@ -99,6 +99,7 @@ Repertoire:
           id: "CL:0000788"
           label: "naive B cell"
         cell_phenotype: "expression of CD20 and the absence of CD27"
+        cell_label: "naive B cell"
         cell_species:
           id: "NCBITAXON:9606"
           label: "Homo sapiens"

--- a/lang/R/tests/data-tests/good_repertoire.yaml
+++ b/lang/R/tests/data-tests/good_repertoire.yaml
@@ -255,6 +255,7 @@ Repertoire:
           id: "CL:0000787"
           label: "memory B cell"
         cell_phenotype: "expression of CD20 and CD27"
+        cell_label: "memory B cell"
         cell_species:
           id: "NCBITAXON:9606"
           label: "Homo sapiens"
@@ -382,7 +383,7 @@ Repertoire:
       link_type: twin
       diagnosis:
         - study_group_description: null
-          diagnosis_timepoint: 
+          diagnosis_timepoint:
             label: Study enrollment
             value: 60
             unit:
@@ -410,6 +411,7 @@ Repertoire:
           id: "CL:0000895"
           label: "naive thymus-derived CD4-positive, alpha-beta T cell"
         cell_phenotype: "expression of CD8 and absence of CD4 and CD45RO"
+        cell_label: "naive CD4+ aB T cell"
         cell_species:
           id: "NCBITAXON:9606"
           label: "Homo sapiens"

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -2516,7 +2516,8 @@ CellProcessing:
                         label: lymphocyte
         cell_phenotype:
             type: string
-            description: List of cellular markers and their expression levels used to isolate the cell population
+            description: >
+                List of cellular markers and their expression levels used to isolate the cell population.
             title: Cell subset phenotype
             example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:
@@ -4587,7 +4588,8 @@ Cell:
                         label: lymphocyte
         cell_phenotype:
             type: string
-            description: List of cellular markers and their expression levels used to isolate the cell population.
+            description: >
+                List of cellular markers and their expression levels used to isolate the cell population.
             title: Cell subset phenotype
             example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -2526,6 +2526,20 @@ CellProcessing:
                 set: 3
                 subset: process (cell)
                 name: Cell subset phenotype
+        cell_label:
+            type: string
+            description: >
+                Free text cell type annotation. Primarily used for annotating cell types that are not 
+                provided in the Cell Ontology.
+            title: Cell annotation
+            example: age-associated B cell
+            x-airr:
+                miairr: defined
+                nullable: true
+                adc-query-support: true
+                set: 3
+                subset: process (cell)
+                name: Cell annotation
         cell_species:
             $ref: '#/Ontology'
             description: >
@@ -4506,7 +4520,6 @@ Cell:
     type: object
     required:
         - cell_id
-        - rearrangements
         - repertoire_id
         - virtual_pairing
     properties:
@@ -4523,32 +4536,6 @@ Cell:
                 nullable: false
                 adc-query-support: true
                 name: Cell index
-        rearrangements:
-            type: array
-            description: >
-                Array of sequence identifiers defined for the Rearrangement objects associated with this cell
-            title: Cell-associated rearrangements
-            items:
-                type: string
-            example: [id1, id2]
-            x-airr:
-                miairr: defined
-                nullable: true
-                adc-query-support: true
-                name: Cell-associated rearrangements
-        receptors:
-            type: array
-            description: >
-                Array of receptor identifiers defined for the Receptor objects associated with this cell
-            title: Cell-associated receptors
-            items:
-                type: string
-            example: [id1, id2]
-            x-airr:
-                miairr: defined
-                nullable: true
-                adc-query-support: true
-                name: Cell-associated receptors
         repertoire_id:
             type: string
             description: Identifier to the associated repertoire in study metadata.
@@ -4567,34 +4554,59 @@ Cell:
                 nullable: true
                 adc-query-support: true
                 name: Data processing for cell
-        expression_study_method:
-            type: string
-            enum:
-                - flow_cytometry
-                - single-cell_transcriptome
-                - null
+        receptors:
+            type: array
             description: >
-                Keyword describing the methodology used to assess expression. This values for this field MUST 
-                come from a controlled vocabulary.
+                Array of receptor identifiers defined for the Receptor objects associated with this cell
+            title: Cell-associated receptors
+            items:
+                type: string
+            example: [id1, id2]
             x-airr:
                 miairr: defined
                 nullable: true
                 adc-query-support: true
-        expression_raw_doi:
+                name: Cell-associated receptors
+        cell_subset:
+            $ref: '#/Ontology'
+            description: Commonly-used designation of isolated cell population.
+            title: Cell subset
+            example:
+                id: CL:0000972
+                label: class switched memory B cell
+            x-airr:
+                miairr: important
+                nullable: true
+                adc-query-support: true
+                name: Cell subset
+                format: ontology
+                ontology:
+                    draft: false
+                    top_node:
+                        id: CL:0000542
+                        label: lymphocyte
+        cell_phenotype:
             type: string
-            description: >
-                DOI of raw data set containing the current event
+            description: List of cellular markers and their expression levels used to isolate the cell population.
+            title: Cell subset phenotype
+            example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:
                 miairr: defined
                 nullable: true
                 adc-query-support: true
-        expression_index:
+                name: Cell subset phenotype
+        cell_label:
             type: string
             description: >
-                Index addressing the current event within the raw data set.
+                Free text cell type annotation. Primarily used for annotating cell types that are not 
+                provided in the Cell Ontology.
+            title: Cell annotation
+            example: age-associated B cell
             x-airr:
                 miairr: defined
                 nullable: true
+                adc-query-support: true
+                name: Cell annotation
         virtual_pairing:
             type: boolean
             description: >
@@ -4606,10 +4618,10 @@ Cell:
                 adc-query-support: true
                 name: Virtual pairing
 
-# The CellExpression object acts as a container to hold a single expression level measurement from
+# The Expression object acts as a container to hold a single expression level measurement from
 # an experiment. Expression data is associated with a cell_id and the related repertoire_id and
-# data_processing_id 
-CellExpression:
+# data_processing_id
+Expression:
     type: object
     required:
         - expression_id
@@ -4623,7 +4635,7 @@ CellExpression:
         expression_id:
             type: string
             description: >
-                Identifier for the CellExpression object. This identifier must be unique within 
+                Identifier for the Expression object. This identifier must be unique within 
                 a given study, but it is recommended that it be a universally unique record locator
                 to enable database applications.
             title: Expression property measurement identifier
@@ -4807,12 +4819,12 @@ Receptor:
                 nullable: true
                 adc-query-support: true
 
-# The CellReactivity object holds information about the reactivity exhibited by a given Cell
+# The Reactivity object holds information about the reactivity exhibited by a given Cell
 #
-CellReactivity:
+Reactivity:
     type: object
     required:
-        - cell_reactivity_id
+        - reactivity_id
         - cell_id
         - ligand_type
         - antigen_type
@@ -4822,13 +4834,13 @@ CellReactivity:
         - reactivity_value
         - reactivity_unit
     properties:
-        cell_reactivity_id:
+        reactivity_id:
             type: string
             description: >
-                Identifier for the CellReactivity object. This identifier must be unique within 
+                Identifier for the Reactivity object. This identifier must be unique within 
                 a given study, but it is recommended that it be a universally unique record locator
                 to enable database applications.
-            title: CellReactivity ID
+            title: Reactivity ID
             x-airr:
                 identifier: true
                 nullable: false

--- a/lang/python/tests/data/good_combined_airr.json
+++ b/lang/python/tests/data/good_combined_airr.json
@@ -589,7 +589,7 @@
                         "label": "naive thymus-derived CD4-positive, alpha-beta T cell"
                     },
                     "cell_phenotype": "expression of CD8 and absence of CD4 and CD45RO",
-                    "cell_label": "naive CD4+ aB T cell",
+                    "cell_label": "naive CD4 aB T cell",
                     "cell_species": {
                         "id": "NCBITAXON:9606",
                         "label": "Homo sapiens"

--- a/lang/python/tests/data/good_combined_airr.json
+++ b/lang/python/tests/data/good_combined_airr.json
@@ -189,6 +189,7 @@
                         "label": "naive B cell"
                     },
                     "cell_phenotype": "expression of CD20 and the absence of CD27",
+                    "cell_label": "naive B cell",
                     "cell_species": {
                         "id": "NCBITAXON:9606",
                         "label": "Homo sapiens"
@@ -388,6 +389,7 @@
                         "label": "memory B cell"
                     },
                     "cell_phenotype": "expression of CD20 and CD27",
+                    "cell_label": "memory B cell",
                     "cell_species": {
                         "id": "NCBITAXON:9606",
                         "label": "Homo sapiens"
@@ -587,6 +589,7 @@
                         "label": "naive thymus-derived CD4-positive, alpha-beta T cell"
                     },
                     "cell_phenotype": "expression of CD8 and absence of CD4 and CD45RO",
+                    "cell_label": "naive CD4+ aB T cell",
                     "cell_species": {
                         "id": "NCBITAXON:9606",
                         "label": "Homo sapiens"

--- a/lang/python/tests/data/good_combined_airr.yaml
+++ b/lang/python/tests/data/good_combined_airr.yaml
@@ -142,10 +142,10 @@ Repertoire:
           id: CL:0000788
           label: naive B cell
         cell_phenotype: expression of CD20 and the absence of CD27
+        cell_label: naive B cell
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens
-        cell_label: naive B cell
         single_cell: false
         cell_isolation: FACS
         template_class: RNA
@@ -474,7 +474,7 @@ Repertoire:
           id: CL:0000895
           label: naive thymus-derived CD4-positive, alpha-beta T cell
         cell_phenotype: expression of CD8 and absence of CD4 and CD45RO
-        cell_label: naive CD4+ aB T cell
+        cell_label: naive CD4 aB T cell
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens

--- a/lang/python/tests/data/good_combined_airr.yaml
+++ b/lang/python/tests/data/good_combined_airr.yaml
@@ -145,6 +145,7 @@ Repertoire:
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens
+        cell_label: naive B cell
         single_cell: false
         cell_isolation: FACS
         template_class: RNA
@@ -307,6 +308,7 @@ Repertoire:
           id: CL:0000787
           label: memory B cell
         cell_phenotype: expression of CD20 and CD27
+        cell_label: memory B cell
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens
@@ -472,6 +474,7 @@ Repertoire:
           id: CL:0000895
           label: naive thymus-derived CD4-positive, alpha-beta T cell
         cell_phenotype: expression of CD8 and absence of CD4 and CD45RO
+        cell_label: naive CD4+ aB T cell
         cell_species:
           id: NCBITAXON:9606
           label: Homo sapiens

--- a/lang/python/tests/data/good_repertoire.yaml
+++ b/lang/python/tests/data/good_repertoire.yaml
@@ -99,6 +99,7 @@ Repertoire:
           id: "CL:0000788"
           label: "naive B cell"
         cell_phenotype: "expression of CD20 and the absence of CD27"
+        cell_label: "naive B cell"
         cell_species:
           id: "NCBITAXON:9606"
           label: "Homo sapiens"

--- a/lang/python/tests/data/good_repertoire.yaml
+++ b/lang/python/tests/data/good_repertoire.yaml
@@ -255,6 +255,7 @@ Repertoire:
           id: "CL:0000787"
           label: "memory B cell"
         cell_phenotype: "expression of CD20 and CD27"
+        cell_label: "memory B cell"
         cell_species:
           id: "NCBITAXON:9606"
           label: "Homo sapiens"
@@ -410,6 +411,7 @@ Repertoire:
           id: "CL:0000895"
           label: "naive thymus-derived CD4-positive, alpha-beta T cell"
         cell_phenotype: "expression of CD8 and absence of CD4 and CD45RO"
+        cell_label: "naive CD4+ aB T cell"
         cell_species:
           id: "NCBITAXON:9606"
           label: "Homo sapiens"

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -4904,10 +4904,10 @@ Cell:
                 adc-query-support: true
                 name: Virtual pairing
 
-# The CellExpression object acts as a container to hold a single expression level measurement from
+# The Expression object acts as a container to hold a single expression level measurement from
 # an experiment. Expression data is associated with a cell_id and the related repertoire_id and
 # data_processing_id.
-CellExpression:
+Expression:
     type: object
     required:
         - expression_id
@@ -4921,7 +4921,7 @@ CellExpression:
         expression_id:
             type: string
             description: >
-                Identifier for the CellExpression object. This identifier must be unique within 
+                Identifier for the Expression object. This identifier must be unique within 
                 a given study, but it is recommended that it be a universally unique record locator
                 to enable database applications.
             title: Expression property measurement identifier
@@ -5106,10 +5106,10 @@ Receptor:
             x-airr:
                 adc-query-support: true
 
-CellReactivity:
+Reactivity:
     type: object
     required:
-        - cell_reactivity_id
+        - reactivity_id
         - cell_id
         - ligand_type
         - antigen_type
@@ -5119,14 +5119,14 @@ CellReactivity:
         - reactivity_value
         - reactivity_unit
     properties:
-        cell_reactivity_id:
+        reactivity_id:
             type: string
             nullable: false
             description: >
-                Identifier for the CellReactivity object. This identifier must be unique within 
+                Identifier for the Reactivity object. This identifier must be unique within 
                 a given study, but it is recommended that it be a universally unique record locator
                 to enable database applications.
-            title: CellReactivity ID
+            title: Reactivity ID
             x-airr:
                 identifier: true
                 adc-query-support: true

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -2610,7 +2610,8 @@ CellProcessing:
         cell_phenotype:
             type: string
             nullable: true
-            description: List of cellular markers and their expression levels used to isolate the cell population
+            description: >
+                List of cellular markers and their expression levels used to isolate the cell population
             title: Cell subset phenotype
             example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:
@@ -2619,6 +2620,20 @@ CellProcessing:
                 set: 3
                 subset: process (cell)
                 name: Cell subset phenotype
+        cell_label:
+            type: string
+            nullable: true
+            description: >
+                Free text cell type annotation. Primarily used for annotating cell types that are not 
+                provided in the Cell Ontology.
+            title: Cell annotation
+            example: age-associated B cell
+            x-airr:
+                miairr: defined
+                adc-query-support: true
+                set: 3
+                subset: process (cell)
+                name: Cell annotation
         cell_species:
             $ref: '#/Ontology'
             nullable: true
@@ -4790,7 +4805,6 @@ Cell:
     type: object
     required:
         - cell_id
-        - rearrangements
         - repertoire_id
         - virtual_pairing
     properties:
@@ -4807,32 +4821,6 @@ Cell:
                 miairr: defined
                 adc-query-support: true
                 name: Cell index
-        rearrangements:
-            type: array
-            nullable: true
-            description: >
-                Array of sequence identifiers defined for the Rearrangement objects associated with this cell
-            title: Cell-associated rearrangements
-            items:
-                type: string
-            example: [id1, id2]
-            x-airr:
-                miairr: defined
-                adc-query-support: true
-                name: Cell-associated rearrangements
-        receptors:
-            type: array
-            nullable: true
-            description: >
-                Array of receptor identifiers defined for the Receptor objects associated with this cell
-            title: Cell-associated receptors
-            items:
-                type: string
-            example: [id1, id2]
-            x-airr:
-                miairr: defined
-                adc-query-support: true
-                name: Cell-associated receptors
         repertoire_id:
             type: string
             nullable: true
@@ -4851,34 +4839,60 @@ Cell:
                 miairr: defined
                 adc-query-support: true
                 name: Data processing for cell
-        expression_study_method:
-            type: string
-            enum:
-                - flow_cytometry
-                - single-cell_transcriptome
-                - null
+        receptors:
+            type: array
             nullable: true
             description: >
-                Keyword describing the methodology used to assess expression. This values for this field MUST 
-                come from a controlled vocabulary.
+                Array of receptor identifiers defined for the Receptor objects associated with this cell
+            title: Cell-associated receptors
+            items:
+                type: string
+            example: [id1, id2]
             x-airr:
                 miairr: defined
                 adc-query-support: true
-        expression_raw_doi:
+                name: Cell-associated receptors
+        cell_subset:
+            $ref: '#/Ontology'
+            nullable: true
+            description: Commonly-used designation of isolated cell population.
+            title: Cell subset
+            example:
+                id: CL:0000972
+                label: class switched memory B cell
+            x-airr:
+                miairr: important
+                adc-query-support: true
+                name: Cell subset
+                format: ontology
+                ontology:
+                    draft: false
+                    top_node:
+                        id: CL:0000542
+                        label: lymphocyte
+        cell_phenotype:
             type: string
             nullable: true
             description: >
-                DOI of raw data set containing the current event
+                List of cellular markers and their expression levels used to isolate the cell population.
+            title: Cell subset phenotype
+            example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:
                 miairr: defined
                 adc-query-support: true
-        expression_index:
+                name: Cell subset phenotype
+        cell_label:
             type: string
             nullable: true
             description: >
-                Index addressing the current event within the raw data set.
+                Free text cell type annotation. Primarily used for annotating cell types that are not 
+                provided in the Cell Ontology.
+            title: Cell annotation
+            example: age-associated B cell
             x-airr:
                 miairr: defined
+                adc-query-support: true
+                name: Cell annotation
         virtual_pairing:
             type: boolean
             nullable: true

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -2611,7 +2611,7 @@ CellProcessing:
             type: string
             nullable: true
             description: >
-                List of cellular markers and their expression levels used to isolate the cell population
+                List of cellular markers and their expression levels used to isolate the cell population.
             title: Cell subset phenotype
             example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2516,7 +2516,8 @@ CellProcessing:
                         label: lymphocyte
         cell_phenotype:
             type: string
-            description: List of cellular markers and their expression levels used to isolate the cell population
+            description: >
+                List of cellular markers and their expression levels used to isolate the cell population.
             title: Cell subset phenotype
             example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:
@@ -4587,7 +4588,8 @@ Cell:
                         label: lymphocyte
         cell_phenotype:
             type: string
-            description: List of cellular markers and their expression levels used to isolate the cell population.
+            description: >
+                List of cellular markers and their expression levels used to isolate the cell population.
             title: Cell subset phenotype
             example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -4506,7 +4506,6 @@ Cell:
     type: object
     required:
         - cell_id
-        - rearrangements
         - repertoire_id
         - virtual_pairing
     properties:
@@ -4523,32 +4522,6 @@ Cell:
                 nullable: false
                 adc-query-support: true
                 name: Cell index
-        rearrangements:
-            type: array
-            description: >
-                Array of sequence identifiers defined for the Rearrangement objects associated with this cell
-            title: Cell-associated rearrangements
-            items:
-                type: string
-            example: [id1, id2]
-            x-airr:
-                miairr: defined
-                nullable: true
-                adc-query-support: true
-                name: Cell-associated rearrangements
-        receptors:
-            type: array
-            description: >
-                Array of receptor identifiers defined for the Receptor objects associated with this cell
-            title: Cell-associated receptors
-            items:
-                type: string
-            example: [id1, id2]
-            x-airr:
-                miairr: defined
-                nullable: true
-                adc-query-support: true
-                name: Cell-associated receptors
         repertoire_id:
             type: string
             description: Identifier to the associated repertoire in study metadata.
@@ -4567,34 +4540,59 @@ Cell:
                 nullable: true
                 adc-query-support: true
                 name: Data processing for cell
-        expression_study_method:
-            type: string
-            enum:
-                - flow_cytometry
-                - single-cell_transcriptome
-                - null
+        receptors:
+            type: array
             description: >
-                Keyword describing the methodology used to assess expression. This values for this field MUST 
-                come from a controlled vocabulary.
+                Array of receptor identifiers defined for the Receptor objects associated with this cell
+            title: Cell-associated receptors
+            items:
+                type: string
+            example: [id1, id2]
             x-airr:
                 miairr: defined
                 nullable: true
                 adc-query-support: true
-        expression_raw_doi:
-            type: string
-            description: >
-                DOI of raw data set containing the current event
+                name: Cell-associated receptors
+        cell_subset:
+            $ref: '#/Ontology'
+            description: Commonly-used designation of isolated cell population.
+            title: Cell subset
+            example:
+                id: CL:0000972
+                label: class switched memory B cell
             x-airr:
                 miairr: defined
                 nullable: true
                 adc-query-support: true
-        expression_index:
+                name: Cell subset
+                format: ontology
+                ontology:
+                    draft: false
+                    top_node:
+                        id: CL:0000542
+                        label: lymphocyte
+        cell_phenotype:
             type: string
-            description: >
-                Index addressing the current event within the raw data set.
+            description: List of cellular markers and their expression levels used to isolate the cell population.
+            title: Cell subset phenotype
+            example: CD19+ CD38+ CD27+ IgM- IgD-
             x-airr:
                 miairr: defined
                 nullable: true
+                adc-query-support: true
+                name: Cell subset phenotype
+        cell_label:
+            type: string
+            description: >
+                Free text cell type annotation. Primarily used for annotating cell types that are not 
+                provided in the Cell Ontology.
+            title: Cell annotation
+            example: age-associated B cell
+            x-airr:
+                miairr: defined
+                nullable: true
+                adc-query-support: true
+                name: Cell annotation
         virtual_pairing:
             type: boolean
             description: >
@@ -4606,10 +4604,10 @@ Cell:
                 adc-query-support: true
                 name: Virtual pairing
 
-# The CellExpression object acts as a container to hold a single expression level measurement from
+# The Expression object acts as a container to hold a single expression level measurement from
 # an experiment. Expression data is associated with a cell_id and the related repertoire_id and
 # data_processing_id 
-CellExpression:
+Expression:
     type: object
     required:
         - expression_id
@@ -4623,7 +4621,7 @@ CellExpression:
         expression_id:
             type: string
             description: >
-                Identifier for the CellExpression object. This identifier must be unique within 
+                Identifier for the Expression object. This identifier must be unique within 
                 a given study, but it is recommended that it be a universally unique record locator
                 to enable database applications.
             title: Expression property measurement identifier
@@ -4807,12 +4805,12 @@ Receptor:
                 nullable: true
                 adc-query-support: true
 
-# The CellReactivity object holds information about the reactivity exhibited by a given Cell
+# The Reactivity object holds information about the reactivity exhibited by a given Cell
 #
-CellReactivity:
+Reactivity:
     type: object
     required:
-        - cell_reactivity_id
+        - reactivity_id
         - cell_id
         - ligand_type
         - antigen_type
@@ -4822,13 +4820,13 @@ CellReactivity:
         - reactivity_value
         - reactivity_unit
     properties:
-        cell_reactivity_id:
+        reactivity_id:
             type: string
             description: >
-                Identifier for the CellReactivity object. This identifier must be unique within 
+                Identifier for the Reactivity object. This identifier must be unique within 
                 a given study, but it is recommended that it be a universally unique record locator
                 to enable database applications.
-            title: CellReactivity ID
+            title: Reactivity ID
             x-airr:
                 identifier: true
                 nullable: false

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2526,6 +2526,20 @@ CellProcessing:
                 set: 3
                 subset: process (cell)
                 name: Cell subset phenotype
+        cell_label:
+            type: string
+            description: >
+                Free text cell type annotation. Primarily used for annotating cell types that are not 
+                provided in the Cell Ontology.
+            title: Cell annotation
+            example: age-associated B cell
+            x-airr:
+                miairr: defined
+                nullable: true
+                adc-query-support: true
+                set: 3
+                subset: process (cell)
+                name: Cell annotation
         cell_species:
             $ref: '#/Ontology'
             description: >
@@ -4561,7 +4575,7 @@ Cell:
                 id: CL:0000972
                 label: class switched memory B cell
             x-airr:
-                miairr: defined
+                miairr: important
                 nullable: true
                 adc-query-support: true
                 name: Cell subset


### PR DESCRIPTION
Initial changes to `Cell`, `CellExpression` and `CellReactivity` per March 4, 2024 call:
* Remove `Rearrangement` and expression links in `Cell`.
* Renamed `CellExpression` to `Expression`.
* Renamed `CellReactivity` to `Reactivity`.

Also:
* Added `cell_subset`, `cell_phenotype`, and `cell_label` for CL term, marker definition, and free text annotation, respectively. 
* Not sure I like these names, but I stuck with what was already in the `CellProcessing` object.
* Not sure we need `cell_phenotype`, but I thought I'd include it for discussion purposes.

I only modified the main v2 spec. I will propagate once we agree on the changes.

Closes #768
Closes #477