### PR TITLE
minimums for physical quantities

### DIFF
--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -1808,6 +1808,7 @@ Subject:
                 format: controlled_vocabulary
         age_min:
             type: number
+            minimum: 0
             description: Specific age or lower boundary of age range.
             title: Age minimum
             example: 60
@@ -1820,6 +1821,7 @@ Subject:
                 name: Age minimum
         age_max:
             type: number
+            minimum: 0
             description: >
                 Upper boundary of age range or equal to age_min for specific age.
                 This field should only be null if age_min is null.
@@ -2318,6 +2320,7 @@ CellProcessing:
                 name: Single-cell sort
         cell_number:
             type: integer
+            minimum: 0
             description: Total number of cells that went into the experiment
             title: Number of cells in experiment
             example: 1000000
@@ -2330,6 +2333,7 @@ CellProcessing:
                 name: Number of cells in experiment
         cells_per_reaction:
             type: integer
+            minimum: 0
             description: Number of cells for each biological replicate
             title: Number of cells per sequencing reaction
             example: 50000
@@ -2497,6 +2501,7 @@ NucleicAcidProcessing:
                 name: Target substrate quality
         template_amount:
             type: number
+            minimum: 0
             description: Amount of template that went into the process
             title: Template amount
             example: 1000

--- a/lang/R/inst/extdata/airr-schema.yaml
+++ b/lang/R/inst/extdata/airr-schema.yaml
@@ -2674,6 +2674,7 @@ SequencingRun:
                 name: Batch number
         total_reads_passing_qc_filter:
             type: integer
+            minimum: 0
             description: Number of usable reads for analysis
             title: Total reads passing QC filter
             example: 10365118
@@ -2816,6 +2817,7 @@ SequencingData:
                 format: controlled_vocabulary
         read_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the first file in paired-read sequencing
             title: Forward read length
             example: 300
@@ -2858,6 +2860,7 @@ SequencingData:
                 format: controlled_vocabulary
         paired_read_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the second file in paired-read sequencing
             title: Paired read length
             example: 300
@@ -2878,6 +2881,7 @@ SequencingData:
                 adc-query-support: true
         index_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the index file
             title: Index read length
             example: 8

--- a/lang/js/airr-schema-openapi3.yaml
+++ b/lang/js/airr-schema-openapi3.yaml
@@ -2777,6 +2777,7 @@ SequencingRun:
         total_reads_passing_qc_filter:
             type: integer
             nullable: true
+            minimum: 0
             description: Number of usable reads for analysis
             title: Total reads passing QC filter
             example: 10365118
@@ -2919,6 +2920,7 @@ SequencingData:
         read_length:
             type: integer
             nullable: true
+            minimum: 0
             description: Read length in bases for the first file in paired-read sequencing
             title: Forward read length
             example: 300
@@ -2961,6 +2963,7 @@ SequencingData:
         paired_read_length:
             type: integer
             nullable: true
+            minimum: 0
             description: Read length in bases for the second file in paired-read sequencing
             title: Paired read length
             example: 300
@@ -2981,6 +2984,7 @@ SequencingData:
         index_length:
             type: integer
             nullable: true
+            minimum: 0
             description: Read length in bases for the index file
             title: Index read length
             example: 8

--- a/lang/js/airr-schema-openapi3.yaml
+++ b/lang/js/airr-schema-openapi3.yaml
@@ -1909,6 +1909,7 @@ Subject:
         age_min:
             type: number
             nullable: true
+            minimum: 0
             description: Specific age or lower boundary of age range.
             title: Age minimum
             example: 60
@@ -1921,6 +1922,7 @@ Subject:
         age_max:
             type: number
             nullable: true
+            minimum: 0
             description: >
                 Upper boundary of age range or equal to age_min for specific age.
                 This field should only be null if age_min is null.
@@ -2421,6 +2423,7 @@ CellProcessing:
         cell_number:
             type: integer
             nullable: true
+            minimum: 0
             description: Total number of cells that went into the experiment
             title: Number of cells in experiment
             example: 1000000
@@ -2433,6 +2436,7 @@ CellProcessing:
         cells_per_reaction:
             type: integer
             nullable: true
+            minimum: 0
             description: Number of cells for each biological replicate
             title: Number of cells per sequencing reaction
             example: 50000
@@ -2600,6 +2604,7 @@ NucleicAcidProcessing:
         template_amount:
             type: number
             nullable: true
+            minimum: 0
             description: Amount of template that went into the process
             title: Template amount
             example: 1000

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -1808,6 +1808,7 @@ Subject:
                 format: controlled_vocabulary
         age_min:
             type: number
+            minimum: 0
             description: Specific age or lower boundary of age range.
             title: Age minimum
             example: 60
@@ -1820,6 +1821,7 @@ Subject:
                 name: Age minimum
         age_max:
             type: number
+            minimum: 0
             description: >
                 Upper boundary of age range or equal to age_min for specific age.
                 This field should only be null if age_min is null.
@@ -2318,6 +2320,7 @@ CellProcessing:
                 name: Single-cell sort
         cell_number:
             type: integer
+            minimum: 0
             description: Total number of cells that went into the experiment
             title: Number of cells in experiment
             example: 1000000
@@ -2330,6 +2333,7 @@ CellProcessing:
                 name: Number of cells in experiment
         cells_per_reaction:
             type: integer
+            minimum: 0
             description: Number of cells for each biological replicate
             title: Number of cells per sequencing reaction
             example: 50000
@@ -2497,6 +2501,7 @@ NucleicAcidProcessing:
                 name: Target substrate quality
         template_amount:
             type: number
+            minimum: 0
             description: Amount of template that went into the process
             title: Template amount
             example: 1000

--- a/lang/python/airr/specs/airr-schema.yaml
+++ b/lang/python/airr/specs/airr-schema.yaml
@@ -2674,6 +2674,7 @@ SequencingRun:
                 name: Batch number
         total_reads_passing_qc_filter:
             type: integer
+            minimum: 0
             description: Number of usable reads for analysis
             title: Total reads passing QC filter
             example: 10365118
@@ -2816,6 +2817,7 @@ SequencingData:
                 format: controlled_vocabulary
         read_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the first file in paired-read sequencing
             title: Forward read length
             example: 300
@@ -2858,6 +2860,7 @@ SequencingData:
                 format: controlled_vocabulary
         paired_read_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the second file in paired-read sequencing
             title: Paired read length
             example: 300
@@ -2878,6 +2881,7 @@ SequencingData:
                 adc-query-support: true
         index_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the index file
             title: Index read length
             example: 8

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -2777,6 +2777,7 @@ SequencingRun:
         total_reads_passing_qc_filter:
             type: integer
             nullable: true
+            minimum: 0
             description: Number of usable reads for analysis
             title: Total reads passing QC filter
             example: 10365118
@@ -2919,6 +2920,7 @@ SequencingData:
         read_length:
             type: integer
             nullable: true
+            minimum: 0
             description: Read length in bases for the first file in paired-read sequencing
             title: Forward read length
             example: 300
@@ -2961,6 +2963,7 @@ SequencingData:
         paired_read_length:
             type: integer
             nullable: true
+            minimum: 0
             description: Read length in bases for the second file in paired-read sequencing
             title: Paired read length
             example: 300
@@ -2981,6 +2984,7 @@ SequencingData:
         index_length:
             type: integer
             nullable: true
+            minimum: 0
             description: Read length in bases for the index file
             title: Index read length
             example: 8

--- a/specs/airr-schema-openapi3.yaml
+++ b/specs/airr-schema-openapi3.yaml
@@ -1909,6 +1909,7 @@ Subject:
         age_min:
             type: number
             nullable: true
+            minimum: 0
             description: Specific age or lower boundary of age range.
             title: Age minimum
             example: 60
@@ -1921,6 +1922,7 @@ Subject:
         age_max:
             type: number
             nullable: true
+            minimum: 0
             description: >
                 Upper boundary of age range or equal to age_min for specific age.
                 This field should only be null if age_min is null.
@@ -2421,6 +2423,7 @@ CellProcessing:
         cell_number:
             type: integer
             nullable: true
+            minimum: 0
             description: Total number of cells that went into the experiment
             title: Number of cells in experiment
             example: 1000000
@@ -2433,6 +2436,7 @@ CellProcessing:
         cells_per_reaction:
             type: integer
             nullable: true
+            minimum: 0
             description: Number of cells for each biological replicate
             title: Number of cells per sequencing reaction
             example: 50000
@@ -2600,6 +2604,7 @@ NucleicAcidProcessing:
         template_amount:
             type: number
             nullable: true
+            minimum: 0
             description: Amount of template that went into the process
             title: Template amount
             example: 1000

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -1808,6 +1808,7 @@ Subject:
                 format: controlled_vocabulary
         age_min:
             type: number
+            minimum: 0
             description: Specific age or lower boundary of age range.
             title: Age minimum
             example: 60
@@ -1820,6 +1821,7 @@ Subject:
                 name: Age minimum
         age_max:
             type: number
+            minimum: 0
             description: >
                 Upper boundary of age range or equal to age_min for specific age.
                 This field should only be null if age_min is null.
@@ -2318,6 +2320,7 @@ CellProcessing:
                 name: Single-cell sort
         cell_number:
             type: integer
+            minimum: 0
             description: Total number of cells that went into the experiment
             title: Number of cells in experiment
             example: 1000000
@@ -2330,6 +2333,7 @@ CellProcessing:
                 name: Number of cells in experiment
         cells_per_reaction:
             type: integer
+            minimum: 0
             description: Number of cells for each biological replicate
             title: Number of cells per sequencing reaction
             example: 50000
@@ -2497,6 +2501,7 @@ NucleicAcidProcessing:
                 name: Target substrate quality
         template_amount:
             type: number
+            minimum: 0
             description: Amount of template that went into the process
             title: Template amount
             example: 1000

--- a/specs/airr-schema.yaml
+++ b/specs/airr-schema.yaml
@@ -2674,6 +2674,7 @@ SequencingRun:
                 name: Batch number
         total_reads_passing_qc_filter:
             type: integer
+            minimum: 0
             description: Number of usable reads for analysis
             title: Total reads passing QC filter
             example: 10365118
@@ -2816,6 +2817,7 @@ SequencingData:
                 format: controlled_vocabulary
         read_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the first file in paired-read sequencing
             title: Forward read length
             example: 300
@@ -2858,6 +2860,7 @@ SequencingData:
                 format: controlled_vocabulary
         paired_read_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the second file in paired-read sequencing
             title: Paired read length
             example: 300
@@ -2878,6 +2881,7 @@ SequencingData:
                 adc-query-support: true
         index_length:
             type: integer
+            minimum: 0
             description: Read length in bases for the index file
             title: Index read length
             example: 8


### PR DESCRIPTION
JSON schema supports defining minimum and maximum values for numbers and integers. As these fields are physical quantities, they should always be positive. Adding these provide for better validation.

I only did for fields in `Repertoire`. We can consider adding for other fields if it makes sense.

This is for V1. Need to think how to do for V2 as we've restructured the fields.